### PR TITLE
Fix gcc 4.9.2 build (Debian jessie):

### DIFF
--- a/src/s3ql/deltadump.pyx
+++ b/src/s3ql/deltadump.pyx
@@ -518,7 +518,7 @@ def load_table(table, columns, db, fh, trx_rows=5000):
                     read_integer(&int64, fp)
                     int64 += col_args[j] + int64_prev[j]
                     int64_prev[j] = int64
-                    SQLITE_CHECK_RC(sqlite3_bind_double(stmt, j + 1, int64 / time_scale),
+                    SQLITE_CHECK_RC(sqlite3_bind_double(stmt, j + 1, <double> int64 / time_scale),
                                     SQLITE_OK, sqlite3_db)
 
                 elif col_types[j] == _BLOB:


### PR DESCRIPTION
src/s3ql/deltadump.c: In function ‘__pyx_pf_4s3ql_9deltadump_4load_table’:
src/s3ql/deltadump.c:6467:154: error: conversion to ‘double’ from ‘int64_t’ may alter its value [-Werror=conversion]
                 __pyx_t_30 = __pyx_f_4s3ql_9deltadump_SQLITE_CHECK_RC(sqlite3_bind_double(__pyx_cur_scope->__pyx_v_stmt, (__pyx_v_j + 1), (__pyx_v_int64 / __pyx_v_4s3ql_9deltadump_time_scale)), SQLITE_OK, __pyx_cur_scope->__pyx_v_sqlite3_db); if (unlikely(__pyx_t_30 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 521; __pyx_clineno = __LINE__; goto __pyx_L8_error;}
                                                                                                                                                          ^
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1