### PR TITLE
Use -Wno-unused-function in developer mode:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ def main():
     if DEVELOPER_MODE:
         compile_args.append('-Werror')
         compile_args.append('-Wfatal-errors')
+        compile_args.append('-Wno-unused-function')
 
     required_pkgs = ['apsw >= 3.7.0',
                      'pycrypto',


### PR DESCRIPTION
/usr/bin/clang -Wno-unused-result -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -pipe -Os -I/opt/local/Library/Frameworks/Python.framework/Versions/3.4/include/python3.4m -c src/s3ql/deltadump.c -o build/temp.macosx-10.11-x86_64-3.4/src/s3ql/deltadump.o -Wall -Wextra -Wconversion -Wsign-compare -Werror=conversion -Werror=sign-compare -Werror -Wfatal-errors
src/s3ql/deltadump.c:11376:32: fatal error: unused function '__Pyx_PyUnicode_FromString' [-Wunused-function] static CYTHON_INLINE PyObject* __Pyx_PyUnicode_FromString(const char* c_str) {
                               ^
1 error generated.
error: command '/usr/bin/clang' failed with exit status 1