### PR TITLE
[IMP] fsck: Allow duplicated object_id while listing

### DIFF
--- a/src/s3ql/fsck.py
+++ b/src/s3ql/fsck.py
@@ -909,7 +909,10 @@ class Fsck(object):
                     log.warning("Ignoring unexpected object %r", obj_name)
                     continue
 
-                self.conn.execute('INSERT INTO obj_ids VALUES(?)', (obj_id,))
+                try:
+                    self.conn.execute('INSERT INTO obj_ids VALUES(?)', (obj_id,))
+                except apsw.ConstraintError:
+                    log.warning("Ignoring duplicated object with ID %r", obj_id)
 
             for (obj_id,) in self.conn.query('SELECT id FROM obj_ids '
                                              'EXCEPT SELECT id FROM objects'):


### PR DESCRIPTION
When listing objects from the backend, sometimes there's a duplicated object that is queried 2 times. With this, we avoid to give a DB duplicated ID constraint error, so that the process can continue.

I see this to be reasonable safely, logged only with a warning, without inconsistency problems.
