### PR TITLE
Github is now the primary issue tracker.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,6 @@ The following resources are available:
   `s3ql+subscribe@googlegroups.com
   <mailto:s3ql+subscribe@googlegroups.com>`_.
 
-Please report any bugs you may encounter in the `Bitbucket Issue Tracker`_.
 
 Contributing
 ============


### PR DESCRIPTION
Refer to https://bitbucket.org/nikratio/s3ql/issues/300/please-report-new-issues-on-github