### PR TITLE
Fixed TypeError in contrib/benchmark.py #22

### DIFF
--- a/contrib/benchmark.py
+++ b/contrib/benchmark.py
@@ -160,10 +160,7 @@ def main(args=None):
     out_speed = dict()
     for alg in ALGS:
         log.info('compressing with %s-6...', alg)
-        temp_parser = argparse.ArgumentParser()
-        temp_parser.add_argument('--storage_url')
-        temp_options = temp_parser.parse_args(['--storage_url','local://' + backend_dir])
-        backend = ComprencBackend(b'pass', (alg, 6),Backend(temp_options))
+        backend = ComprencBackend(b'pass', (alg, 6),Backend(argparse.Namespace(storage_url='local://' + backend_dir)))
         def do_write(dst): #pylint: disable=E0102
             src.seek(0)
             stamp = time.time()

--- a/contrib/benchmark.py
+++ b/contrib/benchmark.py
@@ -160,7 +160,10 @@ def main(args=None):
     out_speed = dict()
     for alg in ALGS:
         log.info('compressing with %s-6...', alg)
-        backend = ComprencBackend(b'pass', (alg, 6), Backend('local://' + backend_dir, None, None))
+        temp_parser = argparse.ArgumentParser()
+        temp_parser.add_argument('--storage_url')
+        temp_options = temp_parser.parse_args(['--storage_url','local://' + backend_dir])
+        backend = ComprencBackend(b'pass', (alg, 6),Backend(temp_options))
         def do_write(dst): #pylint: disable=E0102
             src.seek(0)
             stamp = time.time()


### PR DESCRIPTION
This is a fix for Issue 22. The Backend class expects to initialize using an argparser  object. The main one cannot be used to hold a local storage url, because it is already being used for the remote url. I used a secondary argparse object as a workaround with minimal changes.