### PR TITLE
Fix s3qladm manpage - "clear" instead of "delete"

### DIFF
--- a/rst/man/adm.rst
+++ b/rst/man/adm.rst
@@ -46,7 +46,7 @@ passphrase
 upgrade
   Upgrade the file system to the newest revision.
 
-delete
+clear
   Delete the file system with all the stored data.
 
 download-metadata


### PR DESCRIPTION
fixes #78 