### PR TITLE
Include pytest execution in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ install:
 script:
   - python setup.py build_cython || travis_terminate 1
   - python setup.py build_ext --inplace || travis_terminate 1
-  - python -m pytest tests/ || travis_terminate 1
+  - python setup.py test || travis_terminate 1
   - python setup.py build_sphinx || travis_terminate 1
   - python setup.py install

--- a/rst/installation.rst
+++ b/rst/installation.rst
@@ -43,7 +43,7 @@ that is not the case.
     version between 1.0 (inclusive) and 2.0 (exclusive)
   * `dugong <https://pypi.org/project/dugong/>`_, any
     version between 3.4 (inclusive) and 4.0 (exclusive)
-  * `pytest <http://pytest.org/>`_, version 2.7 or newer (optional, to run unit tests)
+  * `pytest <http://pytest.org/>`_, version 3.7 or newer (optional, to run unit tests)
   * `systemd <https://github.com/systemd/python-systemd>`_ (optional,
     for enabling systemd support). Do *not* install the module from
     PyPi, this is from a third-party developer and incompatible with
@@ -102,7 +102,7 @@ tested with ::
 
   python3 setup.py build_cython
   python3 setup.py build_ext --inplace
-  python3 -m pytest tests/
+  python3 setup.py test
 
 Note that when building from the Mercurial or Git repository, building
 and testing is done with several additional checks. This may cause

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 # Don't automatically download and install any dependencies
 [easy_install]
 allow_hosts = None
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ def main():
                          ]
                           },
           install_requires=required_pkgs,
+          tests_require=['pytest >= 3.7']
           cmdclass={'upload_docs': upload_docs,
                     'build_cython': build_cython,
                     'build_sphinx': build_docs,

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ def main():
                          ]
                           },
           install_requires=required_pkgs,
-          tests_require=['pytest >= 3.7']
+          tests_require=['pytest >= 3.7'],
           cmdclass={'upload_docs': upload_docs,
                     'build_cython': build_cython,
                     'build_sphinx': build_docs,

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ except ImportError:
     raise SystemExit('Setuptools package not found. Please install from '
                      'https://pypi.python.org/pypi/setuptools')
 from setuptools import Extension
+from setuptools.command.test import test as TestCommand
 
 from distutils.version import LooseVersion
 import os
@@ -105,6 +106,16 @@ class build_docs(setuptools.Command):
                   os.path.join(dest_dir, 'manual.pdf'))
 
 
+class pytest(TestCommand):
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(['tests'])
+        sys.exit(errno)
+
+
 def main():
 
     with open(os.path.join(basedir, 'README.rst'), 'r') as fh:
@@ -185,7 +196,8 @@ def main():
           install_requires=required_pkgs,
           cmdclass={'upload_docs': upload_docs,
                     'build_cython': build_cython,
-                    'build_sphinx': build_docs },
+                    'build_sphinx': build_docs,
+                    'pytest': pytest },
           command_options={ 'sdist': { 'formats': ('setup.py', 'bztar') } },
          )
 


### PR DESCRIPTION
A simplified version of pytest's [Good Integration Practices - Manual Integration](https://docs.pytest.org/en/latest/goodpractices.html#manual-integration). I didn't get the [`pytest-runner` version](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner) to work, but I think the manual approach is better here anyway because we don't add another dependency and the test execution class is pretty simple.

Closes #86 