### PR TITLE
Track last write instead of last access

### DIFF
--- a/src/s3ql/block_cache.py
+++ b/src/s3ql/block_cache.py
@@ -149,7 +149,7 @@ class CacheEntry(object):
     :pos: current position in file
     """
 
-    __slots__ = [ 'dirty', 'inode', 'blockno', 'last_access',
+    __slots__ = [ 'dirty', 'inode', 'blockno', 'last_write',
                   'size', 'pos', 'fh', 'removed' ]
 
     def __init__(self, inode, blockno, filename, mode='w+b'):
@@ -161,7 +161,7 @@ class CacheEntry(object):
         self.dirty = False
         self.inode = inode
         self.blockno = blockno
-        self.last_access = 0
+        self.last_write = 0
         self.pos = self.fh.tell()
         self.size = os.fstat(self.fh.fileno()).st_size
 
@@ -195,6 +195,7 @@ class CacheEntry(object):
         self.fh.write(buf)
         self.pos += len(buf)
         self.size = max(self.pos, self.size)
+        self.last_write = time.time()
 
     def close(self):
         self.fh.close()
@@ -785,7 +786,6 @@ class BlockCache(object):
         self._lock_entry(inode, blockno, release_global=True)
         try:
             el = self._get_entry(inode, blockno)
-            el.last_access = time.time()
             oldsize = el.size
             try:
                 yield el

--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -731,7 +731,7 @@ class CommitThread(Thread):
                 # ... number=500)/500 * 1e3
                 # 1.456586996000624
                 for el in list(self.block_cache.cache.values()):
-                    if self.stop_event.is_set() or stamp - el.last_access < 10:
+                    if self.stop_event.is_set() or stamp - el.last_write < 10:
                         break
                     if el.dirty and el not in self.block_cache.in_transit:
                         self.block_cache.upload_if_dirty(el)


### PR DESCRIPTION
It seems to me that currently, `last_access` of a cache entry is only used for determining when to upload it to the backend, i.e., tracking read access is currently not needed. Therefore, I suggest to simply rename the flag to `last_write` and update it in the `write` method instead of the `get` method.

Closes #55 