### PR TITLE
Specify requirements only in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ before_install:
   - "printf 'Current libsqlite3-dev version: %s' $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"
 
 install:
-  - pip install https://github.com/rogerbinns/apsw/releases/download/3.8.2-r1/apsw-3.8.2-r1.zip
-  - pip install defusedxml
-  - pip install cython==0.28.2 sphinx cryptography requests "llfuse >= 1.0, < 2.0" "dugong >= 3.4, < 4.0" "pytest >= 3.7"
+  - pip install .
 
 script:
   - python setup.py build_cython || travis_terminate 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Install requirements from setup.py
+--index-url https://pypi.python.org/simple/
+-e .

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ sys.path.insert(0, os.path.join(basedir, 'util'))
 
 # Get S3QL Version & Release from __init__.py
 with open('src/s3ql/__init__.py', 'r') as init_file:
-    content = init_file.read()
-    VERSION = re.compile("^VERSION\s*=\s*'(\d+\.\d+)'", re.MULTILINE).search().groups(0)[0]
-    RELEASE_SUFFIX = re.compile("^RELEASE_SUFFIX\s*=\s*'(.*)'", re.MULTILINE).search().groups(0)[0]
+    init_content = init_file.read()
+    VERSION = re.compile("^VERSION\s*=\s*'(\d+\.\d+)'", re.MULTILINE).search(init_content).groups(0)[0]
+    RELEASE_SUFFIX = re.compile("^RELEASE_SUFFIX\s*=\s*'(.*)'", re.MULTILINE).search(init_content).groups(0)[0]
     RELEASE = ' '.join([VERSION, RELEASE_SUFFIX]).strip()
 
 class build_docs(setuptools.Command):

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,13 @@ if DEVELOPER_MODE:
 sys.path.insert(0, os.path.join(basedir, 'src'))
 sys.path.insert(0, os.path.join(basedir, 'util'))
 
-# Get S3QL Version & Release from __init__.py
-with open('src/s3ql/__init__.py', 'r') as init_file:
-    init_content = init_file.read()
-    VERSION = re.compile("^VERSION\s*=\s*'(\d+\.\d+)'", re.MULTILINE).search(init_content).groups(0)[0]
-    RELEASE_SUFFIX = re.compile("^RELEASE_SUFFIX\s*=\s*'(.*)'", re.MULTILINE).search(init_content).groups(0)[0]
-    RELEASE = ' '.join([VERSION, RELEASE_SUFFIX]).strip()
+# Get S3QL Version from __init__.py
+with open(os.path.join(basedir, 'src', 's3ql', '__init__.py'), 'r') as init_fh:
+    for line in init_fh:
+        match = re.match("^VERSION\s*=\s*'(\d+\.\d+)'", line)
+        if match:
+            VERSION = match.group(1)
+            break
 
 class build_docs(setuptools.Command):
     description = 'Build Sphinx documentation'
@@ -75,7 +76,7 @@ class build_docs(setuptools.Command):
 
         confoverrides = {}
         confoverrides['version'] = VERSION
-        confoverrides['release'] = RELEASE
+        confoverrides['release'] = VERSION
 
         for builder in ('html', 'latex', 'man'):
             print('Running %s builder...' % builder)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,13 @@ if DEVELOPER_MODE:
 # Add S3QL sources
 sys.path.insert(0, os.path.join(basedir, 'src'))
 sys.path.insert(0, os.path.join(basedir, 'util'))
-import s3ql
+
+# Get S3QL Version & Release from __init__.py
+with open('src/s3ql/__init__.py', 'r') as init_file:
+    content = init_file.read()
+    VERSION = re.compile("^VERSION\s*=\s*'(\d+\.\d+)'", re.MULTILINE).search().groups(0)[0]
+    RELEASE_SUFFIX = re.compile("^RELEASE_SUFFIX\s*=\s*'(.*)'", re.MULTILINE).search().groups(0)[0]
+    RELEASE = ' '.join([VERSION, RELEASE_SUFFIX]).strip()
 
 class build_docs(setuptools.Command):
     description = 'Build Sphinx documentation'
@@ -68,8 +74,8 @@ class build_docs(setuptools.Command):
         src_dir = os.path.join(basedir, 'rst')
 
         confoverrides = {}
-        confoverrides['version'] = s3ql.VERSION
-        confoverrides['release'] = s3ql.RELEASE
+        confoverrides['version'] = VERSION
+        confoverrides['release'] = RELEASE
 
         for builder in ('html', 'latex', 'man'):
             print('Running %s builder...' % builder)
@@ -150,7 +156,7 @@ def main():
     setuptools.setup(
           name='s3ql',
           zip_safe=True,
-          version=s3ql.VERSION,
+          version=VERSION,
           description='a full-featured file system for online data storage',
           long_description=long_desc,
           author='Nikolaus Rath',

--- a/src/s3ql/__init__.py
+++ b/src/s3ql/__init__.py
@@ -38,8 +38,11 @@ assert logging.LOG_ONCE  # prevent warnings about unused module
 
 from llfuse import ROOT_INODE
 
+# The RELEASE information is built from 'VERSION RELEASE_SUFFIX'
+# E.g., if VERSION='3.1' and RELEASE_SUFFIX='(beta)', RELEASE will be '3.0 (beta)'
 VERSION = '3.0'
-RELEASE = '%s' % VERSION
+RELEASE_SUFFIX = ''
+RELEASE = ' '.join([VERSION, RELEASE_SUFFIX]).strip()
 
 # TODO: On next revision bump, remove upgrade code from backend/comprenc.py and
 # backends/s3c.py (activated by UPGRADE_MODE variable).

--- a/src/s3ql/__init__.py
+++ b/src/s3ql/__init__.py
@@ -38,11 +38,7 @@ assert logging.LOG_ONCE  # prevent warnings about unused module
 
 from llfuse import ROOT_INODE
 
-# The RELEASE information is built from 'VERSION RELEASE_SUFFIX'
-# E.g., if VERSION='3.1' and RELEASE_SUFFIX='(beta)', RELEASE will be '3.0 (beta)'
 VERSION = '3.0'
-RELEASE_SUFFIX = ''
-RELEASE = ' '.join([VERSION, RELEASE_SUFFIX]).strip()
 
 # TODO: On next revision bump, remove upgrade code from backend/comprenc.py and
 # backends/s3c.py (activated by UPGRADE_MODE variable).

--- a/src/s3ql/parse_args.py
+++ b/src/s3ql/parse_args.py
@@ -34,7 +34,7 @@ are:
 #pylint: disable-all
 
 from .logging import logging # Ensure use of custom logger class
-from . import RELEASE
+from . import VERSION
 from .backends import prefix_map
 from .common import _escape
 from getpass import getpass
@@ -138,7 +138,7 @@ class ArgumentParser(argparse.ArgumentParser):
     def add_version(self):
         self.add_argument('--version', action='version',
                           help="just print program version and exit",
-                          version='S3QL %s' % RELEASE)
+                          version='S3QL %s' % VERSION)
 
     def add_quiet(self):
         self.add_argument("--quiet", action="store_true", default=False,


### PR DESCRIPTION
- Add a requirements.txt file ( fixes #51 )
- Use the requirements specified in setup.py also in the Travis build configuration