### PR TITLE
Ability to select S3 storage class INTELLIGENT_TIERING

### DIFF
--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -150,6 +150,11 @@ The Amazon S3 backend accepts the following backend options:
     Enable server side encryption. Both costs & benefits of S3 server
     side encryption are probably rather small, and this option does
     *not* affect any client side encryption performed by S3QL itself.
+    
+.. option:: it
+
+   Use INTELLIGENT_TIERING storage class for new objects.
+   See `AWS S3 Storage classes<https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html>`_
 
 .. option:: ia
 

--- a/src/s3ql/backends/s3.py
+++ b/src/s3ql/backends/s3.py
@@ -36,7 +36,7 @@ class Backend(s3c.Backend):
     may or may not be available and can be queried for with instance methods.
     """
 
-    known_options = ((s3c.Backend.known_options | {'sse', 'rrs', 'ia', 'oia'})
+    known_options = ((s3c.Backend.known_options | {'sse', 'rrs', 'ia', 'oia', 'it'})
                      - {'dumb-copy', 'disable-expect100'})
 
     def __init__(self, options):
@@ -96,6 +96,8 @@ class Backend(s3c.Backend):
             sc = 'ONEZONE_IA'
         elif 'rrs' in self.options:
             sc = 'REDUCED_REDUNDANCY'
+        elif 'it' in self.options:
+            sc = 'INTELLIGENT_TIERING'
         else:
             sc = 'STANDARD'
         headers['x-amz-storage-class'] = sc


### PR DESCRIPTION
I've added an option called `it` for the S3 backend that allows for the usage of the new INTELLIGENT_TIERING storage class.