### PR TITLE
Updated to support the Keystone v3 API

### DIFF
--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -195,12 +195,13 @@ authentication, the storage URL is ::
 
    swift://<hostname>[:<port>]/<container>[/<prefix>]
 
-for Keystone (v2) authentication, the storage URL is ::
+for Keystone (v2 and v3) authentication, the storage URL is ::
 
    swiftks://<hostname>[:<port>]/<region>:<container>[/<prefix>]
 
 Note that when using Keystone authentication, you can (and have to)
-specify the storage region of the container as well.
+specify the storage region of the container as well. Also note that when
+using Keystone v3 authentication, the `domain` option is required.
 
 In both cases, *hostname* name should be the name of the
 authentication server.  The storage container must already exist (most
@@ -255,6 +256,14 @@ The OpenStack backend accepts the following backend options:
    advanced features of the Swift backend. In this case S3QL can only
    use the least common denominator of supported Swift versions and
    configurations.
+
+.. option:: domain
+
+   If this option is specified, S3QL will use the Keystone v3 API. The
+   default domain for OpenStack installations is `Default`. Note: some
+   instances of the Keystone v3 API prefer the use of UUIDs rather than
+   names for tenant (called project in newer OpenStack versions), and
+   domain.
 
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3
 .. _OpenStack: http://www.openstack.org/

--- a/src/s3ql/backends/swift.py
+++ b/src/s3ql/backends/swift.py
@@ -40,7 +40,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
     hdr_prefix = 'X-Object-'
     known_options = {'no-ssl', 'ssl-ca-path', 'tcp-timeout',
                      'disable-expect100', 'no-feature-detection',
-                     'v3-auth', 'domain'}
+                     'domain'}
 
     _add_meta_headers = s3c.Backend._add_meta_headers
     _extractmeta = s3c.Backend._extractmeta

--- a/src/s3ql/backends/swift.py
+++ b/src/s3ql/backends/swift.py
@@ -39,7 +39,8 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
 
     hdr_prefix = 'X-Object-'
     known_options = {'no-ssl', 'ssl-ca-path', 'tcp-timeout',
-                     'disable-expect100', 'no-feature-detection'}
+                     'disable-expect100', 'no-feature-detection',
+                     'v3-auth', 'domain'}
 
     _add_meta_headers = s3c.Backend._add_meta_headers
     _extractmeta = s3c.Backend._extractmeta

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -76,18 +76,56 @@ class Backend(swift.Backend):
             tenant = None
             user = self.login
 
-        auth_body = { 'auth':
+        if self.options.get('v3-auth', False):
+            domain = self.options.get('domain', 'Default')
+
+            if not tenant:
+                raise ValueError("Tenant is required when v3-auth is enabled")
+
+            auth_body = {
+                'auth': {
+                    'identity': {
+                        'methods': ['password'],
+                        'password': {
+                            'user': {
+                                'name': user,
+                                'domain': {
+                                    'id': domain
+                                },
+                                'password': self.password
+                            }
+                        }
+                    },
+                    'scope': {
+                        'project': {
+                            'id': tenant,
+                            'domain': {
+                                'id': domain
+                            }
+                        }
+                    }
+                }
+            }
+
+            auth_url_path = '/v3/auth/tokens'
+
+        else:
+            # If not v3-auth, assume v2
+            auth_body = { 'auth':
                           { 'passwordCredentials':
                                 { 'username': user,
                                   'password': self.password } }}
-        if tenant:
-            auth_body['auth']['tenantName'] = tenant
+
+            auth_url_path = '/v2.0/tokens'
+
+            if tenant:
+                auth_body['auth']['tenantName'] = tenant
 
         with HTTPConnection(self.hostname, port=self.port, proxy=self.proxy,
                             ssl_context=ssl_context) as conn:
             conn.timeout = int(self.options.get('tcp-timeout', 20))
 
-            conn.send_request('POST', '/v2.0/tokens', headers=headers,
+            conn.send_request('POST', auth_url_path, headers=headers,
                               body=json.dumps(auth_body).encode('utf-8'))
             resp = conn.read_response()
 
@@ -98,10 +136,16 @@ class Backend(swift.Backend):
                 raise HTTPError(resp.status, resp.reason, resp.headers)
 
             cat = json.loads(conn.read().decode('utf-8'))
-            self.auth_token = cat['access']['token']['id']
+
+            if self.options.get('v3-auth', False):
+                self.auth_token = resp.headers['X-Subject-Token']
+                service_catalog = cat['token']['catalog']
+            else:
+                self.auth_token = cat['access']['token']['id']
+                service_catalog = cat['access']['serviceCatalog']
 
         avail_regions = []
-        for service in cat['access']['serviceCatalog']:
+        for service in service_catalog:
             if service['type'] != 'object-store':
                 continue
 
@@ -110,7 +154,17 @@ class Backend(swift.Backend):
                     avail_regions.append(endpoint['region'])
                     continue
 
-                o = urlsplit(endpoint['publicURL'])
+                if 'publicURL' in endpoint:
+                    # The publicURL nomenclature is found in v2 catalogs
+                    o = urlsplit(endpoint['publicURL'])
+                else:
+                    # Whereas v3 catalogs do 'interface' == 'public' and
+                    # 'url' for the URL itself
+                    if endpoint['interface'] != 'public':
+                        continue
+
+                    o = urlsplit(endpoint['url'])
+
                 self.auth_prefix = urllib.parse.unquote(o.path)
                 if o.scheme == 'https':
                     ssl_context = self.ssl_context

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -76,11 +76,10 @@ class Backend(swift.Backend):
             tenant = None
             user = self.login
 
-        if self.options.get('v3-auth', False):
-            domain = self.options.get('domain', 'Default')
-
+        domain = self.options.get('domain', None)
+        if domain:
             if not tenant:
-                raise ValueError("Tenant is required when v3-auth is enabled")
+                raise ValueError("Tenant is required when Keystone v3 is used")
 
             auth_body = {
                 'auth': {
@@ -110,7 +109,7 @@ class Backend(swift.Backend):
             auth_url_path = '/v3/auth/tokens'
 
         else:
-            # If not v3-auth, assume v2
+            # If a domain is not specified, assume v2
             auth_body = { 'auth':
                           { 'passwordCredentials':
                                 { 'username': user,


### PR DESCRIPTION
This code was tested against a Red Hat OSP 13 (based on OpenStack Queens) cloud. It should be noted that in some cases, the v3 API can be cranky about names versus IDs. The documentation should be updated to include a recommendation to use IDs for domain and project (aka tenant) instead of text names.