### PR TITLE
Fixed errant reference to vestigial backend option

### DIFF
--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -260,10 +260,17 @@ The OpenStack backend accepts the following backend options:
 .. option:: domain
 
    If this option is specified, S3QL will use the Keystone v3 API. The
-   default domain for OpenStack installations is `Default`. Note: some
+   default domain for OpenStack installations is `Default`. If this
+   option is specified without setting the `project-domain` option, this
+   will be used for both the project and the user domain. Note: some
    instances of the Keystone v3 API prefer the use of UUIDs rather than
-   names for tenant (called project in newer OpenStack versions), and
-   domain.
+   names for tenant (called project in newer OpenStack versions), as
+   well as domains.
+
+.. option:: project-domain
+   In simple cases, the project domain will be the same as the auth
+   domain. If the `project-domain` option is not specified, it will be
+   assumed to be the same as the user domain.
 
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3
 .. _OpenStack: http://www.openstack.org/

--- a/src/s3ql/backends/swift.py
+++ b/src/s3ql/backends/swift.py
@@ -40,7 +40,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
     hdr_prefix = 'X-Object-'
     known_options = {'no-ssl', 'ssl-ca-path', 'tcp-timeout',
                      'disable-expect100', 'no-feature-detection',
-                     'domain'}
+                     'domain', 'project_domain'}
 
     _add_meta_headers = s3c.Backend._add_meta_headers
     _extractmeta = s3c.Backend._extractmeta

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -136,7 +136,7 @@ class Backend(swift.Backend):
 
             cat = json.loads(conn.read().decode('utf-8'))
 
-            if self.options.get('v3-auth', False):
+            if self.options.get('domain', None):
                 self.auth_token = resp.headers['X-Subject-Token']
                 service_catalog = cat['token']['catalog']
             else:

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -81,6 +81,11 @@ class Backend(swift.Backend):
             if not tenant:
                 raise ValueError("Tenant is required when Keystone v3 is used")
 
+            # In simple cases where there's only one domain, the project domain
+            # will be the same as the authentication domain, but this option
+            # allows for them to be different
+            project_domain = self.options.get('project-domain', domain)
+
             auth_body = {
                 'auth': {
                     'identity': {
@@ -99,7 +104,7 @@ class Backend(swift.Backend):
                         'project': {
                             'id': tenant,
                             'domain': {
-                                'id': domain
+                                'id': project_domain
                             }
                         }
                     }


### PR DESCRIPTION
The code that I pushed (that was subject of the last pull request) somehow was missing this change; my apologies!