### PR TITLE
Swift: Throw NoSuchObject when source of copy was not found

### DIFF
--- a/src/s3ql/backends/swift.py
+++ b/src/s3ql/backends/swift.py
@@ -641,7 +641,12 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
         if metadata is not None:
             self._add_meta_headers(headers, metadata, chunksize=self.features.max_meta_len)
             headers['X-Fresh-Metadata'] = 'true'
-        resp = self._do_request('COPY', '/%s%s' % (self.prefix, src), headers=headers)
+        try:
+            resp = self._do_request('COPY', '/%s%s' % (self.prefix, src), headers=headers)
+        except HTTPError as exc:
+            if exc.status == 404:
+                raise NoSuchObject(src)
+            raise
         self._assert_empty_response(resp)
 
     @copy_ancestor_docstring


### PR DESCRIPTION
The older implementation _copy_via_put already converts 404 HTTPError to NoSuchObject.
The newer _copy_via_copy was missing that.

This should fix the problem described here https://groups.google.com/d/msgid/s3ql/df2a63a1-9d1d-4a31-96f5-ce00f20e4afa%40googlegroups.com