### PR TITLE
Catch NoSuchObject when trying to retrieve s3ql_metadata (s3ql#133)

### DIFF
--- a/src/s3ql/common.py
+++ b/src/s3ql/common.py
@@ -324,6 +324,9 @@ def get_backend_factory(options):
             except CorruptedObjectError:
                 raise QuietError('File system revision needs upgrade '
                                  '(or backend data is corrupted)', exitcode=32)
+            except NoSuchObject:
+                raise QuietError('No S3QL file system found at given storage URL.',
+                                 exitcode=18)
 
     return lambda: ComprencBackend(data_pw, compress, options.backend_class(options))
 


### PR DESCRIPTION
Fsck fails with an NoSuchObject exception if tried on none existant
filesystem.

Signed-off-by: Tor Krill <tor@openproducts.se>