### PR TITLE
Fix Travis builds

### DIFF
--- a/tests/travis-install.sh
+++ b/tests/travis-install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install fuse
-sudo python3 -m pip install meson==0.44
+sudo -H python3 -m pip install meson==0.44 --no-cache-dir
 wget https://github.com/libfuse/libfuse/archive/master.zip
 unzip master.zip
 cd libfuse-master
@@ -11,7 +11,7 @@ mkdir build
 cd build
 meson ..
 ninja
-sudo ninja install
+sudo -H ninja install
 test -e /usr/local/lib/pkgconfig || sudo mkdir /usr/local/lib/pkgconfig
 sudo mv /usr/local/lib/*/pkgconfig/* /usr/local/lib/pkgconfig/
 ls -d1 /usr/local/lib/*-linux-gnu | sudo tee /etc/ld.so.conf.d/usrlocal.conf
@@ -26,10 +26,14 @@ pip install defusedxml \
             requests \
             "pyfuse3 >= 1.0, < 2.0" \
             "dugong >= 3.4, < 4.0" \
-            "pytest >= 3.7" \
+            "pytest == 4.6.5" \
             google-auth \
             google-auth-oauthlib \
             pytest_trio \
-            "trio == 0.12.1"
+            "trio == 0.11.0" \
+            "attrs == 19.3.0"
 
-printf 'Current libsqlite3-dev version: %s' $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)
+echo "Current libsqlite3-dev version: $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"
+
+echo "Installed PIP versions:"
+pip freeze


### PR DESCRIPTION
Looks like `trio` and `outcome` need `attr > 0.19.0`. This should fix the errors. 

```
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    import s3ql
  File "/home/travis/build/s3ql/s3ql/src/s3ql/__init__.py", line 39, in <module>
    from pyfuse3 import ROOT_INODE
  File "src/pyfuse3.pyx", line 68, in init pyfuse3
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/trio/__init__.py", line 18, in <module>
    from ._core import (
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/trio/_core/__init__.py", line 19, in <module>
    from ._run import (
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/trio/_core/_run.py", line 22, in <module>
    from outcome import Error, Value, capture
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/outcome/__init__.py", line 11, in <module>
    from ._async import Error, Outcome, Value, acapture, capture
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/outcome/_async.py", line 3, in <module>
    from ._sync import Error as ErrorBase
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/outcome/_sync.py", line 28, in <module>
    class Outcome(ABC):
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/outcome/_sync.py", line 43, in Outcome
    _unwrapped = attr.ib(default=False, eq=False, init=False)
TypeError: attrib() got an unexpected keyword argument 'eq'
```