### PR TITLE
Account for truncated results with no Keys

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # Don't automatically download and install any dependencies
 [easy_install]
-allow_hosts = None
+allow_hosts = https://pypi.org/simple/pyfuse3/ 
 
 [aliases]
 test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # Don't automatically download and install any dependencies
 [easy_install]
-allow_hosts = https://pypi.org/simple/pyfuse3/ 
+allow_hosts = None 
 
 [aliases]
 test=pytest

--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -272,7 +272,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
         if is_truncated.text == 'false':
             page_token = None
         elif len(names) == 0:
-            page_token = etree.find(root_xmlns_prefix + 'NextContinuationToke')
+            page_token = etree.find(root_xmlns_prefix + 'NextContinuationToken')
         else:
             page_token = names[-1]
 

--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -271,6 +271,8 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
         is_truncated = etree.find(root_xmlns_prefix + 'IsTruncated')
         if is_truncated.text == 'false':
             page_token = None
+        elif len(names) == 0:
+            page_token = etree.find(root_xmlns_prefix + 'NextContinuationToke')
         else:
             page_token = names[-1]
 

--- a/tests/travis-install.sh
+++ b/tests/travis-install.sh
@@ -24,7 +24,7 @@ pip install defusedxml \
             sphinx \
             cryptography \
             requests \
-            "pyfuse3 >= 1.0, < 2.0" \
+            "pyfuse3 >= 3.0, < 4.0" \
             "dugong >= 3.4, < 4.0" \
             "pytest == 4.6.5" \
             google-auth \


### PR DESCRIPTION
When running fsck.s3ql, there is a point where a GET is done on the bucket to get the contents.  This was failing as follows:

Running fsck.s3ql on the S3QL filesystem...

Error Code: 1
An unrecoverable error occurred while attempting to run fsck.s3ql on the filesystem.
...
2020-05-08 16:02:14.204 913 INFO     MainThread s3ql.fsck.check_objects_id: Checking objects (backend)...
2020-05-08 16:02:14.204 913 DEBUG    MainThread s3ql.backends.s3c._do_request: started with GET /?None, qs={'prefix': 'avpxhzZPPCGhyjZs3ql_data_', 'max-keys': '1000'}
2020-05-08 16:02:14.205 913 DEBUG    MainThread s3ql.backends.s3c._send_request: sending GET /openlab23-db/?prefix=avpxhzZPPCGhyjZs3ql_data_&max-keys=1000
2020-05-08 16:02:44.293 913 INFO     MainThread s3ql.fsck.check: Dropping temporary indices...
2020-05-08 16:02:44.320 913 ERROR    MainThread root.excepthook: Uncaught top-level exception:
Traceback (most recent call last):
  File "/usr/local/bin/fsck.s3ql", line 11, in <module>
    load_entry_point('s3ql==3.3.2', 'console_scripts', 'fsck.s3ql')()
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 1279, in main
    fsck.check(check_cache)
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 92, in check
    self.check_objects_id()
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 956, in check_objects_id
    for (i, obj_name) in enumerate(self.backend.list('s3ql_data_')):
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/s3c.py", line 234, in list
    (els, page_token) = self._list_page(prefix, page_token)
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/common.py", line 108, in wrapped
    return method(*a, **kw)
  File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/s3c.py", line 275, in _list_page
    page_token = names[-1]
IndexError: list index out of range

I saw that the "aws s3 ls" and "aws s3api" list-objects commands did not have this issue.  I turned on the --debug flag and saw that the first two gets returned no "Contents" or "Keys" but it did say "IsTruncated" was true.   It does this for two requests before it actually starts returning "Contents" and "Keys":

2020-05-13 10:56:49,928 - MainThread - botocore.parsers - DEBUG - Response body:
b'<?xml version="1.0" encoding="UTF-8"?>\n<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>openlab23-db-backup</Name><Prefix></Prefix><KeyCount>1</KeyCount><MaxKeys>1000</MaxKeys><Delimiter>/</Delimiter><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><CommonPrefixes><Prefix>avpxhzZPPCGhyjZ/</Prefix></CommonPrefixes></ListBucketResult>'
...
2020-05-13 11:32:09,938 - MainThread - botocore.parsers - DEBUG - Response body:
b'<?xml version="1.0" encoding="UTF-8"?>\n<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>openlab23-db</Name><Prefix></Prefix><NextContinuationToken>avpxhzZPPCGhyjZs3ql_data_2033301</NextContinuationToken><KeyCount>0</KeyCount><MaxKeys>1000</MaxKeys><Delimiter>/</Delimiter><EncodingType>url</EncodingType><IsTruncated>true</IsTruncated></ListBucketResult>'
...
2020-05-13 11:33:10,434 - MainThread - botocore.parsers - DEBUG - Response body:
b'<?xml version="1.0" encoding="UTF-8"?>\n<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>openlab23-db</Name><Prefix></Prefix><ContinuationToken>avpxhzZPPCGhyjZs3ql_data_2972600</ContinuationToken><NextContinuationToken>avpxhzZPPCGhyjZs3ql_data_4216403</NextContinuationToken><KeyCount>205</KeyCount><MaxKeys>1000</MaxKeys><Delimiter>/</Delimiter><EncodingType>url</EncodingType><IsTruncated>true</IsTruncated><Contents><Key>avpxhzZPPCGhyjZs3ql_data_4106841</Key><LastModified>2020-05-01T23:07:28.971Z</LastModified><ETag>&quot;e28e2dbdc33eb412e661ad204b1fbb3c&quot;
...

The code assumes that there will always be "Contents" and "Key" in the response but that is not what AWS was returning.  I went ahead and updated the code to account for this scenario.