### PR TITLE
Travis: Pin pytest-trio to 0.5.2

### DIFF
--- a/tests/travis-install.sh
+++ b/tests/travis-install.sh
@@ -29,8 +29,8 @@ pip install defusedxml \
             "pytest == 4.6.5" \
             google-auth \
             google-auth-oauthlib \
-            pytest_trio \
-            "trio == 0.12.0" \
+            "pytest_trio == 0.5.2" \
+            "trio == 0.12.1" \
             "attrs == 19.3.0"
 
 echo "Current libsqlite3-dev version: $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"


### PR DESCRIPTION
Looks like the current pytest-trio (0.6.0) does not work with trio 0.12 anymore.

See https://github.com/python-trio/pytest-trio/commit/9572aaff6010aad79280950392d56155949203d5

I do not know if updating trio to 0.15.0 is easily possible or more involved. So for now I just pinned pytest-trio to the older version.