### PR TITLE
Handle listObjects response that contains no keys but is truncated

### DIFF
--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -271,6 +271,9 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
         is_truncated = etree.find(root_xmlns_prefix + 'IsTruncated')
         if is_truncated.text == 'false':
             page_token = None
+        elif len(names) == 0:
+            next_marker = etree.find(root_xmlns_prefix + 'NextMarker')
+            page_token = next_marker.text
         else:
             page_token = names[-1]
 


### PR DESCRIPTION
When running fsck.s3ql, there is a point where a GET is done on the bucket to get the contents. This was failing as follows:

Running fsck.s3ql on the S3QL filesystem...

Error Code: 1
An unrecoverable error occurred while attempting to run fsck.s3ql on the filesystem.
...
2020-05-08 16:02:14.204 913 INFO MainThread s3ql.fsck.check_objects_id: Checking objects (backend)...
2020-05-08 16:02:14.204 913 DEBUG MainThread s3ql.backends.s3c.do_request: started with GET /?None, qs={'prefix': 'avpxhzZPPCGhyjZs3ql_data', 'max-keys': '1000'}
2020-05-08 16:02:14.205 913 DEBUG MainThread s3ql.backends.s3c.send_request: sending GET /openlab23-db/?prefix=avpxhzZPPCGhyjZs3ql_data&max-keys=1000
2020-05-08 16:02:44.293 913 INFO MainThread s3ql.fsck.check: Dropping temporary indices...
2020-05-08 16:02:44.320 913 ERROR MainThread root.excepthook: Uncaught top-level exception:
Traceback (most recent call last):
File "/usr/local/bin/fsck.s3ql", line 11, in
load_entry_point('s3ql==3.3.2', 'console_scripts', 'fsck.s3ql')()
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 1279, in main
fsck.check(check_cache)
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 92, in check
self.check_objects_id()
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/fsck.py", line 956, in check_objects_id
for (i, obj_name) in enumerate(self.backend.list('s3ql_data_')):
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/s3c.py", line 234, in list
(els, page_token) = self._list_page(prefix, page_token)
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/common.py", line 108, in wrapped
return method(*a, **kw)
File "/usr/local/lib/python3.6/dist-packages/s3ql-3.3.2-py3.6-linux-x86_64.egg/s3ql/backends/s3c.py", line 275, in _list_page
page_token = names[-1]
IndexError: list index out of range

I saw that the "aws s3 ls" and "aws s3api" list-objects commands did not have this issue. I turned on the --debug flag and saw that the first two gets returned no "Contents" or "Keys" but it did say "IsTruncated" was true. It does this for two requests before it actually starts returning "Contents" and "Keys":

2020-05-13 10:56:49,928 - MainThread - botocore.parsers - DEBUG - Response body:
b'\nopenlab23-db-backup11000/urlfalseavpxhzZPPCGhyjZ/'
...
2020-05-13 11:32:09,938 - MainThread - botocore.parsers - DEBUG - Response body:
b'\nopenlab23-dbavpxhzZPPCGhyjZs3ql_data_203330101000/urltrue'
...
2020-05-13 11:33:10,434 - MainThread - botocore.parsers - DEBUG - Response body:
b'\nopenlab23-dbavpxhzZPPCGhyjZs3ql_data_2972600avpxhzZPPCGhyjZs3ql_data_42164032051000/urltrueavpxhzZPPCGhyjZs3ql_data_41068412020-05-01T23:07:28.971Z"e28e2dbdc33eb412e661ad204b1fbb3c"
...

The code assumes that there will always be "Contents" and "Key" in the response but that is not what AWS was returning. I went ahead and updated the code to account for this scenario.  The changes have been tested with --debug enabled and everything works as expected (fsck completes successfully using the correct markers).