### PR TITLE
Resolves mounting issue when metadata upload interval is set to zero

### DIFF
--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -598,13 +598,13 @@ class MetadataUploadTask:
         log.debug('started')
 
         assert self.fs is not None
-        if self.interval == None:
-            log.info('Metadata upload disabled.')
-            self.quit = True
 
         while not self.quit:
-            with trio.move_on_after(self.interval):
+            if self.interval == None:
                 await self.event.wait()
+            else:
+                with trio.move_on_after(self.interval):
+                    await self.event.wait()
 
             if self.quit:
                 break

--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -600,7 +600,7 @@ class MetadataUploadTask:
         assert self.fs is not None
 
         while not self.quit:
-            if self.interval == None:
+            if self.interval is None:
                 await self.event.wait()
             else:
                 with trio.move_on_after(self.interval):

--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -598,6 +598,9 @@ class MetadataUploadTask:
         log.debug('started')
 
         assert self.fs is not None
+        if self.interval == None:
+            log.info('Metadata upload disabled.')
+            self.quit = True
 
         while not self.quit:
             with trio.move_on_after(self.interval):


### PR DESCRIPTION
On version 3.4.1 of s3ql, mounting with a metadata upload interval set to 0 would cause the mount operation to fail due to an invalid comparison as seen in mount.log:

oot@6a3b18ffdfa6:~/.s3ql# cat mount.log
2020-05-27 13:55:12.909 1114:MainThread s3ql.mount.determine_threads: Using 4 upload threads.
2020-05-27 13:55:12.909 1114:MainThread s3ql.mount.main: Autodetected 1048532 file descriptors available for cache entries
2020-05-27 13:55:13.105 1114:MainThread s3ql.mount.get_metadata: Using cached metadata.
2020-05-27 13:55:13.107 1114:MainThread s3ql.mount.main_async: Mounting s3c://mysystem:8082/amyv-archive-1/PVC6E+fXa9DxDb4 at /mnt/s3mount...
2020-05-27 13:55:13.113 1117:MainThread s3ql.daemonize.detach_process_context: Daemonizing, new PID is 1119
2020-05-27 13:55:13.134 1119:MainThread py.warnings._showwarnmsg: /usr/local/lib/python3.7/dist-packages/s3ql-3.4.1-py3.7-linux-x86_64.egg/s3ql/block_cache.py:220: TrioDeprecationWarning: trio.hazmat is deprecated since Trio 0.15.0; use trio.lowlevel instead (https://github.com/python-trio/trio/issues/476)

2020-05-27 13:55:13.146 1119:MainThread py.warnings._showwarnmsg: /usr/local/lib/python3.7/dist-packages/_pyfuse3.py:30: TrioDeprecationWarning: trio.hazmat is deprecated since Trio 0.15.0; use trio.lowlevel instead (https://github.com/python-trio/trio/issues/476)
  await fn(*args, **kwargs)

2020-05-27 13:55:13.148 1119:MainThread s3ql.mount.unmount: Unmounting file system...
2020-05-27 13:55:13.149 1119:MainThread root.excepthook: Uncaught top-level exception:
Traceback (most recent call last):
  File "/usr/local/bin/mount.s3ql", line 11, in <module>
    load_entry_point('s3ql==3.4.1', 'console_scripts', 'mount.s3ql')()
  File "/usr/local/lib/python3.7/dist-packages/s3ql-3.4.1-py3.7-linux-x86_64.egg/s3ql/mount.py", line 131, in main
    trio.run(main_async, options, stdout_log_handler)
  File "/usr/local/lib/python3.7/dist-packages/trio/_core/_run.py", line 1718, in run
    raise runner.main_task_outcome.error
  File "/usr/local/lib/python3.7/dist-packages/s3ql-3.4.1-py3.7-linux-x86_64.egg/s3ql/mount.py", line 270, in main_async
    unmount_clean = True
  File "/usr/local/lib/python3.7/dist-packages/trio/_core/_run.py", line 723, in __aexit__
    raise combined_error_from_nursery
  File "/usr/local/lib/python3.7/dist-packages/s3ql-3.4.1-py3.7-linux-x86_64.egg/s3ql/mount.py", line 603, in run
    with trio.move_on_after(self.interval):
  File "/usr/local/lib/python3.7/dist-packages/trio/_timeouts.py", line 29, in move_on_after
    if seconds < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'

This occurs because earlier in the code, the interval is set to "None" if a value of 0 is provide.  It then tries to compare against an integer value which fails.  The code has been update to bypass this altogether by immediately exiting the MetadataUploadTask if the metadata upload interval is "None".

This fix has been tested both with the default metadata upload interval and with a metadata upload interval of 0.