### PR TITLE
Check if statefile exists before attempting to rename

### DIFF
--- a/contrib/expire_backups.py
+++ b/contrib/expire_backups.py
@@ -124,7 +124,8 @@ def main(args=None):
         log.info('Saving state..')
         with open(options.state + '.new', 'wb') as fh:
             fh.write(freeze_basic_mapping(state))
-        os.rename(options.state, options.state + '.bak')
+        if os.path.exists(options.state):
+            os.rename(options.state, options.state + '.bak')
         os.rename(options.state + '.new', options.state)
 
 def upgrade_to_state(backup_list):


### PR DESCRIPTION
Fixes #174 