### PR TITLE
Support for O_TRUNC in the open() syscall

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,7 @@
+UNRELEASED CHANGES
+
+  * The open() syscall supports the O_TRUNC flag now.
+
 2020-09-04, S3QL 3.5.1
 
   * `s3qlctrl upload-meta` now works properly again (previously, only the first


### PR DESCRIPTION
Hi @Nikratio,

looks like re-using the `setattr` code for truncation for the O_TRUNC support is the easiest route.

Fixes #182 