### PR TITLE
Fix Inode cache "BUG ALERT" (garbage collected inode with changes not commited) in _rename()

### DIFF
--- a/src/s3ql/fs.py
+++ b/src/s3ql/fs.py
@@ -717,10 +717,11 @@ class Operations(pyfuse3.Operations):
                                                name_id_old, id_p_old))
 
         inode_p_old = self.inodes[id_p_old]
-        inode_p_new = self.inodes[id_p_new]
         inode_p_old.mtime_ns = now_ns
-        inode_p_new.mtime_ns = now_ns
         inode_p_old.ctime_ns = now_ns
+
+        inode_p_new = self.inodes[id_p_new]
+        inode_p_new.mtime_ns = now_ns
         inode_p_new.ctime_ns = now_ns
 
     def _replace(self, id_p_old, name_old, id_p_new, name_new,


### PR DESCRIPTION
Hello,

Ok I got it!
I found a sure way to reproduce the "BUG ALERT" bug I had very very very randomly. (Or, at least one of them...)
To reproduce, create a brand new, uncompressed, unencrypted, up-to-date S3QL filesystem on a local:// backend.

Then run : 
```bash
#! /bin/bash
set -eu

# Base of the S3QL mount
BASEPATH=/home/nand/tmp/s3qllocal-mounted

# Prepare some folder/files
mkdir $BASEPATH/dest-folder
mkdir $BASEPATH/origin-folder
touch $BASEPATH/origin-folder/boo
# Clear inode cache
for i in {5..200}
do
  touch $BASEPATH/fill-inode-$i
done

# Reload some inodes in a particular order
touch $BASEPATH
touch $BASEPATH/dest-folder
touch $BASEPATH/origin-folder
# Put them on the brink of being flushed
for i in {204..301}
do
  touch $BASEPATH/fill-inode-$i
done
# This will trigger the bug
mv $BASEPATH/origin-folder/boo $BASEPATH/dest-folder/boo2

```

This will trigger : 

```
ERROR: Uncaught top-level exception:
Traceback (most recent call last):
  File "/home/nand/Code/ordissimo/s3ql/src/s3ql/inode_cache.py", line 90, in __del__
    raise RuntimeError('BUG ALERT: Dirty inode was destroyed!')
RuntimeError: BUG ALERT: Dirty inode was destroyed!
Exception ignored in: <bound method _Inode.__del__ of <s3ql.inode_cache._Inode object at 0x7f7c073e94c8>>
Traceback (most recent call last):
  File "/home/nand/Code/ordissimo/s3ql/src/s3ql/inode_cache.py", line 94, in __del__
    sys.excepthook(*exc_info)
  File "/home/nand/Code/ordissimo/s3ql/src/s3ql/mount.py", line 684, in exchook
    old_exchook(exc_type, exc_inst, tb)
  File "/home/nand/Code/ordissimo/s3ql/src/s3ql/logging.py", line 150, in excepthook
    sys.exit(1)
```

The attached commit fixes this.
I looked and looked for a async/await related bug... and it was finally just 2 inodes loaded and edited at the same place :-)

The bug : 
 If you move a file from a folder to another, and the inode cache happens to be in a very specific condition (file to be copied uncached, destination folder in cache about to be evicted on next inode cache miss, origin folder in cache about to be evicted next after).
- fs.py:654 Reduce a lot the occurence of this bug by ensuring the origin and destination folder are in inode cache
- fs.py:658 self._lookup() load the inode of the file to be copied, evicting the destination folder inode.
- fs.py:719 self.inodes[id_p_old] Load the origin folder which was still in cache
- fs.py:720 self.inodes[id_p_new] Load the destination folder, evicts the origin folder inode.
- fs.py:721/723 Changes are made on the origin folder inode, which is no longer handled by the inode cache. We have the bug.
