### PR TITLE
Runs tests that need FUSE with `tests/run-tests-via-docker.sh`

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,12 +21,6 @@ RUN /travis-install.sh
 
 ADD . /build
 WORKDIR /build
-RUN python setup.py build_cython \
- && python setup.py build_ext --inplace \
- && python setup.py test \
- && python setup.py build_sphinx \
- && python setup.py install
-
-FROM scratch AS export
-COPY --from=build /build/doc/ /doc/
-COPY --from=build /build/src/s3ql/deltadump.c /src/s3ql/deltadump.c
+RUN ln -sf /usr/local/bin/fusermount3 /bin/fusermount \
+ && python setup.py build_cython \
+ && python setup.py build_ext --inplace

--- a/tests/run-tests-via-docker.sh
+++ b/tests/run-tests-via-docker.sh
@@ -4,6 +4,17 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/.." || exit 1
 
-# run tests in docker and copy documentation to /build/
-# use BuildKit when available so that the --output option works on macOS
-DOCKER_BUILDKIT=1 docker build -f ./tests/Dockerfile -o "./build" .
+set -e
+
+# build a fresh container (with current sources, will mostly get cached in subsequent calls)
+docker build -f ./tests/Dockerfile  -t s3ql-tests .
+# run tests in docker, pass down arguments to pytest
+if [ "$#" -eq 0 ]; then
+  PY_TEST_ARGS=( tests )
+else
+  PY_TEST_ARGS=( "$@" )
+fi
+docker run --rm \
+           --device /dev/fuse \
+           --cap-add SYS_ADMIN \
+           s3ql-tests python -m pytest "${PY_TEST_ARGS[@]}"


### PR DESCRIPTION
Since `docker build` cannot use the device `/dev/fuse` we need to split the test running up into two parts, building the container and then run the tests.

Added the possibility to pass in pytest command line arguments.
E.g. `tests/run-tests-via-docker.sh tests/t5_failsafe.py::TestSigInt::test` will only execute this one test.