### PR TITLE
Add support for setting the dirty block upload delay

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -4,6 +4,9 @@ UNRELEASED CHANGES
 
   * `mount.s3ql` now exits gracefully on CTRL-C (INT signal)
 
+  * `mount.s3ql` now supports the `--dirty-block-upload-delay` option to influence the
+    time before dirty blocks are written from the cache to the storage backend. 
+
 2020-09-04, S3QL 3.5.1
 
   * `s3qlctrl upload-meta` now works properly again (previously, only the first

--- a/rst/mount.rst
+++ b/rst/mount.rst
@@ -96,8 +96,9 @@ Cache Flushing and Expiration
 -----------------------------
 
 S3QL flushes changed blocks in the cache to the backend whenever a block
-has not been accessed for at least 10 seconds. Note that when a block is
-flushed, it still remains in the cache.
+has not been accessed for at least 10 seconds by default. This time can
+be influenced using the :cmdopt:`--dirty-block-upload-delay` option. Note
+that when a block is flushed, it still remains in the cache.
 
 Cache expiration (i.e., removal of blocks from the cache) is only done
 when the maximum cache size is reached. S3QL always expires the least


### PR DESCRIPTION
This PR adds the `--dirty-block-upload-delay` option to configure the time before dirty blocks are written to the storage backend.