### PR TITLE
Use "name" for auth body attributes intead of "id"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 /tests/.pytest_cache/
 /tests/test.log
 /tests/test_crit.log
+/.history

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,6 +1,6 @@
 UNRELEASED CHANGES
   * Added ability to specify domain-name, project-domain-name and tenant-name as options
-    for the s3 backend for providers that prefer name to id.
+    for the OpenStack Swift (Keystone v3) backend for providers that prefer name to id.
 
   * The open() syscall supports the O_TRUNC flag now.
 

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,4 +1,6 @@
 UNRELEASED CHANGES
+  * Added ability to specify domain-name, project-domain-name and tenant-name as options
+    for the s3 backend for providers that prefer name to id.
 
   * The open() syscall supports the O_TRUNC flag now.
 

--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -269,6 +269,12 @@ The OpenStack backend accepts the following backend options:
    If your provider did not give you a domain ID, then it is most likely
    :var:`default`.
 
+.. option:: domain-name
+
+   If your provider only supplies you with the name of your domain and not the uuid,
+   you need to use this :var:`domain-name` option. If :var:`domain-name` is provided,
+   the :var:`domain` option will not be used.
+
 .. option:: project-domain
 
    In simple cases, the project domain will be the same as the auth
@@ -277,6 +283,18 @@ The OpenStack backend accepts the following backend options:
    You need to provide the domain ID not the domain name to this option.
    If your provider did not give you a domain ID, then it is most likely
    :var:`default`.
+
+.. option:: project-domain-name
+
+   If your provider only supplies you with the name of your project domain and not the uuid,
+   you need to use this :var:`project-domain-name` option. If :var:`project-domain-name` is provided,
+   the :var:`project-domain` option will not be used.
+
+.. option:: tenant-name
+
+   Some providers use the tenant name to specify the storage location, and others use the tenant id.
+   If your provider uses the tenant name and not the id, you need to use this :var:`tenant-name` option.
+   If :var:`tenant-name` is provided, the :var:`<tenant>` component of the login will not be used.
 
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3
 .. _OpenStack: http://www.openstack.org/

--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -269,11 +269,10 @@ The OpenStack backend accepts the following backend options:
    If your provider did not give you a domain ID, then it is most likely
    :var:`default`.
 
-.. option:: domain-name
+.. option:: domain-is-name
 
    If your provider only supplies you with the name of your domain and not the uuid,
-   you need to use this :var:`domain-name` option. If :var:`domain-name` is provided,
-   the :var:`domain` option will not be used.
+   you need to use this :var:`domain-is-name` option as True, whereby the :var:`domain` is used as the name, not the id.
 
 .. option:: project-domain
 
@@ -284,17 +283,19 @@ The OpenStack backend accepts the following backend options:
    If your provider did not give you a domain ID, then it is most likely
    :var:`default`.
 
-.. option:: project-domain-name
+.. option:: project-domain-is-name
 
    If your provider only supplies you with the name of your project domain and not the uuid,
-   you need to use this :var:`project-domain-name` option. If :var:`project-domain-name` is provided,
-   the :var:`project-domain` option will not be used.
+   you need to use this :var:`project-domain-name` option as True, whereby the :var:`project-domain` is used
+   as the name of the project domain, not the id of the project domain.
+   If project-domain-is-name is not specified, it is assumed the same as domain-is-name.
 
-.. option:: tenant-name
+.. option:: tenant-is-name
 
    Some providers use the tenant name to specify the storage location, and others use the tenant id.
-   If your provider uses the tenant name and not the id, you need to use this :var:`tenant-name` option.
-   If :var:`tenant-name` is provided, the :var:`<tenant>` component of the login will not be used.
+   If your provider uses the tenant name and not the id, you need to use this :var:`tenant-is-name` option.
+   If :var:`tenant-is-name` is provided and is True, the :var:`<tenant>` component of the login is used as the tenant
+   name, not the tenant id.
 
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3
 .. _OpenStack: http://www.openstack.org/

--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -272,7 +272,8 @@ The OpenStack backend accepts the following backend options:
 .. option:: domain-is-name
 
    If your provider only supplies you with the name of your domain and not the uuid,
-   you need to use this :var:`domain-is-name` option as True, whereby the :var:`domain` is used as the name, not the id.
+   you need to set this :var:`domain-is-name` option, whereby the :var:`domain` is used as the domain name,
+   not the domain id.
 
 .. option:: project-domain
 
@@ -286,15 +287,15 @@ The OpenStack backend accepts the following backend options:
 .. option:: project-domain-is-name
 
    If your provider only supplies you with the name of your project domain and not the uuid,
-   you need to use this :var:`project-domain-name` option as True, whereby the :var:`project-domain` is used
+   you need to set this :var:`project-domain-name` option, whereby the :var:`project-domain` is used
    as the name of the project domain, not the id of the project domain.
-   If project-domain-is-name is not specified, it is assumed the same as domain-is-name.
+   If project-domain-is-name is not set, it is assumed the same as domain-is-name.
 
 .. option:: tenant-is-name
 
    Some providers use the tenant name to specify the storage location, and others use the tenant id.
-   If your provider uses the tenant name and not the id, you need to use this :var:`tenant-is-name` option.
-   If :var:`tenant-is-name` is provided and is True, the :var:`<tenant>` component of the login is used as the tenant
+   If your provider uses the tenant name and not the id, you need to set this :var:`tenant-is-name` option.
+   If :var:`tenant-is-name` is provided, the :var:`<tenant>` component of the login is used as the tenant
    name, not the tenant id.
 
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3

--- a/src/s3ql/backends/swift.py
+++ b/src/s3ql/backends/swift.py
@@ -39,8 +39,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
 
     hdr_prefix = 'X-Object-'
     known_options = {'no-ssl', 'ssl-ca-path', 'tcp-timeout',
-                     'disable-expect100', 'no-feature-detection',
-                     'domain', 'project_domain'}
+                     'disable-expect100', 'no-feature-detection'}
 
     _add_meta_headers = s3c.Backend._add_meta_headers
     _extractmeta = s3c.Backend._extractmeta

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -94,7 +94,7 @@ class Backend(swift.Backend):
                             'user': {
                                 'name': user,
                                 'domain': {
-                                    'id': domain
+                                    'name': domain
                                 },
                                 'password': self.password
                             }
@@ -102,9 +102,9 @@ class Backend(swift.Backend):
                     },
                     'scope': {
                         'project': {
-                            'id': tenant,
+                            'name': tenant,
                             'domain': {
-                                'id': project_domain
+                                'name': project_domain
                             }
                         }
                     }

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -80,11 +80,11 @@ class Backend(swift.Backend):
             user = self.login
 
         # We can optionally configure with tenant name instead of id.
-        tenant_is_name = self.options.get('tenant-is-name', False)
+        tenant_is_name = 'tenant-is-name' in self.options
 
         # We can configure with domain as id or name.
         domain = self.options.get('domain', None)
-        domain_is_name = self.options.get('domain-is-name', False)
+        domain_is_name = 'domain-is-name' in self.options
         if domain:
             if not tenant:
                 raise ValueError("Tenant is required when Keystone v3 is used")
@@ -94,7 +94,7 @@ class Backend(swift.Backend):
             # allows for them to be different
             # We can configure with project-domain as id or name
             project_domain = self.options.get('project-domain', domain)
-            project_domain_is_name = self.options.get('project-domain-is-name', domain_is_name)
+            project_domain_is_name = ('project-domain-is-name' in self.options) or domain_is_name
 
             auth_body = {
                 'auth': {

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class Backend(swift.Backend):
 
     # Add the options for the v3 keystore swift.
-    known_options = swift.Backend.known_options | {'domain', 'project_domain', 'project-domain-name', 'domain-name', 'tenant-name'}
+    known_options = swift.Backend.known_options | {'domain', 'project-domain', 'project-domain-name', 'domain-name', 'tenant-name'}
 
     def __init__(self, options):
         self.region = None


### PR DESCRIPTION
This seems to be more compatible with providers, and is in the example provided on the openstack website: https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail#password-authentication-with-unscoped-authorization

It is also the technique that the python swift stack uses. "python-swiftclient"

This has been tested on https://cloud.idrive.com

Previously using "id" did not work.