### PR TITLE
Add support for custom identity url in Swiftks backend

### DIFF
--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -298,6 +298,11 @@ The OpenStack backend accepts the following backend options:
    If :var:`tenant-is-name` is provided, the :var:`<tenant>` component of the login is used as the tenant
    name, not the tenant id.
 
+.. option:: identity-url
+
+   If your provider does not use hostname:port/v3/auth/tokens but instead has another identity URL, you can use this option.
+   It allows to replace /v3/auth/tokens with another path like for example /identity/v3/auth/tokens
+
 .. __: http://tools.ietf.org/html/rfc2616#section-8.2.3
 .. _OpenStack: http://www.openstack.org/
 .. _Swift: http://openstack.org/projects/storage/

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class Backend(swift.Backend):
 
     # Add the options for the v3 keystore swift.
-    known_options = swift.Backend.known_options | {'domain', 'project-domain', 'project-domain-is-name', 'domain-is-name', 'tenant-is-name', 'custom-auth-url'}
+    known_options = swift.Backend.known_options | {'domain', 'project-domain', 'project-domain-is-name', 'domain-is-name', 'tenant-is-name', 'identity-url'}
 
     def __init__(self, options):
         self.region = None
@@ -121,8 +121,8 @@ class Backend(swift.Backend):
                 }
             }
 
-            if 'custom-auth-url' in self.options:
-                auth_url_path = self.options['custom-auth-url']
+            if 'identity-url' in self.options:
+                auth_url_path = self.options['identity-url']
             else:
                 auth_url_path = '/v3/auth/tokens'
 

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class Backend(swift.Backend):
 
     # Add the options for the v3 keystore swift.
-    known_options = swift.Backend.known_options | {'domain', 'project-domain', 'project-domain-is-name', 'domain-is-name', 'tenant-is-name'}
+    known_options = swift.Backend.known_options | {'domain', 'project-domain', 'project-domain-is-name', 'domain-is-name', 'tenant-is-name', 'custom-auth-url'}
 
     def __init__(self, options):
         self.region = None
@@ -121,7 +121,7 @@ class Backend(swift.Backend):
                 }
             }
 
-            auth_url_path = '/v3/auth/tokens'
+            auth_url_path = ('custom-auth-url' in self.options) or '/v3/auth/tokens'
 
         else:
             # If a domain is not specified, assume v2

--- a/src/s3ql/backends/swiftks.py
+++ b/src/s3ql/backends/swiftks.py
@@ -121,7 +121,10 @@ class Backend(swift.Backend):
                 }
             }
 
-            auth_url_path = ('custom-auth-url' in self.options) or '/v3/auth/tokens'
+            if 'custom-auth-url' in self.options:
+                auth_url_path = self.options['custom-auth-url']
+            else:
+                auth_url_path = '/v3/auth/tokens'
 
         else:
             # If a domain is not specified, assume v2


### PR DESCRIPTION
As background: I have a swift server I want to connect to which requires the auth URL to be in this format:
/identity/v3/auth/tokens

And I can of course hardcode it in a fork to be with /identity in front of it, but that's not a clean solution. 
So I thought it would be nice to maybe have support for custom auth URLs with s3ql officially. 

Which I tried to, do but unfortunately I am not experienced with or have ever largely used python besides very basic things.

I copied the code from this function "project_domain_is_name = ('project-domain-is-name' in self.options) or domain_is_name"
But it doesn't work for me in this new way while the connection was working with hardcoding it from "/v3/auth/tokens" to "/identity/v3/auth/tokens" so my change isn't doing what I expected it to. (most likely cause I simply did it wrong)


Do you know perhaps what I'm doing wrong in changing the code to add support for custom auth URLs?