### PR TITLE
S3: use newer S3 endpoint hostnames

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,7 @@
+UNRELEASED CHANGES
+
+  * S3QL now supports newer AWS S3 regions like eu-south-1.
+
 2020-11-09, S3QL 3.6.0
 
   * Added ability to specify domain-name, project-domain-name and tenant-name as options

--- a/src/s3ql/backends/s3.py
+++ b/src/s3ql/backends/s3.py
@@ -56,12 +56,10 @@ class Backend(s3c.Backend):
         if not re.match('^[a-z0-9][a-z0-9.-]{1,60}[a-z0-9]$', bucket_name):
             raise QuietError('Invalid bucket name.', exitcode=2)
 
-        if self.region == 'us-east-1':
-            hostname = 's3.amazonaws.com'
-        elif self.region.startswith('cn-'):
+        if self.region.startswith('cn-'):
             hostname = 's3.%s.amazonaws.com.cn' % self.region
         else:
-            hostname = 's3-%s.amazonaws.com' % self.region
+            hostname = 's3.%s.amazonaws.com' % self.region
 
         prefix = hit.group(3) or ''
         port = 443 if ssl_context else 80


### PR DESCRIPTION
These endpoints should work with newer regions like eu-south-1, too.
The special case for us-east-1 is not needed anymore.

Should fix #223 

Since I have no S3QL filesystem on AWS I did not do a real life test of this change – maybe @jonnypa can test this?
I tested the new endpoint scheme with all endpoints I found here https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html#Concepts.RegionsAndAvailabilityZones.Availability

```shell
for R in eu-central-1 eu-west-1 eu-west-2 eu-south-1 eu-west-3 \
  eu-north-1 me-south-1 sa-east-1 us-gov-east-1 us-gov-west-1 \
  ca-central-1 us-east-2 us-east-1 us-west-1 us-west-2 af-south-1 \
  ap-east-1 ap-south-1 ap-northeast-3 ap-northeast-2 ap-southeast-1 \
  ap-southeast-2 ap-northeast-1 not-a-region; do 
    ( (($(dig +noall +answer "s3.$R.amazonaws.com" | wc -c)>0)) && echo "s3.$R.amazonaws.com OK" ) || echo "s3.$R.amazonaws.com ERROR"; 
done
for R in cn-north-1 cn-northwest-1 not-a-region; do 
    ( (($(dig +noall +answer "s3.$R.amazonaws.com.cn" | wc -c)>0)) && echo "s3.$R.amazonaws.com.cn OK" ) || echo "s3.$R.amazonaws.com.cn ERROR"; 
done

```
