### PR TITLE
Fix logging of unhandled exceptions on upload threads

### DIFF
--- a/src/s3ql/block_cache.py
+++ b/src/s3ql/block_cache.py
@@ -340,7 +340,8 @@ class BlockCache(object):
                 self.db.execute('UPDATE objects SET size=? WHERE id=?', (obj_size, obj_id))
                 el.dirty = False
             else:
-                log.debug('upload of %d failed', obj_id, exc_info=exc_info)
+                exc = exc_info[1]
+                log.debug('upload of %d failed (%s: %s)', obj_id, type(exc).__name__, exc)
                 # At this point we have to remove references to this storage object
                 # from the objects and blocks table to prevent future cache elements
                 # to be de-duplicated against this (missing) one. However, this may

--- a/src/s3ql/block_cache.py
+++ b/src/s3ql/block_cache.py
@@ -335,12 +335,12 @@ class BlockCache(object):
             return fh
 
         success = False
-        async def with_event_loop():
+        async def with_event_loop(exc_info):
             if success:
                 self.db.execute('UPDATE objects SET size=? WHERE id=?', (obj_size, obj_id))
                 el.dirty = False
             else:
-                log.debug('upload of %d failed', obj_id, exc_info=True)
+                log.debug('upload of %d failed', obj_id, exc_info=exc_info)
                 # At this point we have to remove references to this storage object
                 # from the objects and blocks table to prevent future cache elements
                 # to be de-duplicated against this (missing) one. However, this may
@@ -385,7 +385,7 @@ class BlockCache(object):
             success = True
         finally:
             self.in_transit.remove(el)
-            trio.from_thread.run(with_event_loop, trio_token=self.trio_token)
+            trio.from_thread.run(with_event_loop, sys.exc_info(), trio_token=self.trio_token)
 
 
     async def wait(self):

--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -684,6 +684,7 @@ def setup_exchook():
                             "(will not be re-raised)")
             else:
                 log.debug('recording exception %s', exc_inst)
+                log.error("Unhandled exception in thread, terminating", exc_info=True)
                 os.kill(os.getpid(), signal.SIGTERM)
                 exc_info.append(exc_inst)
                 exc_info.append(tb)


### PR DESCRIPTION
- fix exception logging in debug output upon failed upload (spurious `NoneType: None`)
- log unhandled exceptions before terminating s3ql in the exception hook