### PR TITLE
More robust expired auth token detection for Google Storage

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -11,6 +11,8 @@ UNRELEASED CHANGES
     `umount.s3ql`, `umount`, or `fusermount -u` and wait for the mount.s3ql process to
     terminate.
 
+  * More robust expired auth token detection for Google Storage.
+
 
 2020-11-09, S3QL 3.6.0
 

--- a/src/s3ql/backends/gs.py
+++ b/src/s3ql/backends/gs.py
@@ -436,12 +436,11 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
             raise ValueError('md5 passed to write_fd does not match fd data')
 
         resp = self.conn.read_response()
-        if resp.status != 200:
+        # If we're really unlucky, then the token has expired while we were uploading data.
+        if resp.status == 401:
+            raise AccessTokenExpired()
+        elif resp.status != 200:
             exc = self._parse_error_response(resp)
-            # If we're really unlucky, then the token has expired while we
-            # were uploading data.
-            if exc.message == 'Invalid Credentials':
-                raise AccessTokenExpired()
             raise _map_request_error(exc, key) or exc
         self._parse_json_response(resp)
 


### PR DESCRIPTION
Google Storage seems to not always respond with a proper JSON response in error cases (especially `401`). The normal flow in `_do_request` does not even try to parse the response in case it gets a `401` error code but just retries the request after an auth token refresh.

This pull request also treats all `401` responses S3QL gets after the initial `100 Continue` response as an auth token expiration.

This should fix #224 

I do not have access to a Google Storage file system. Maybe @Grunthos can test this pull request (it is slightly different than the hotfix I proposed in #224).