### PR TITLE
gs: also retry update_meta for temporary failures

### DIFF
--- a/src/s3ql/backends/gs.py
+++ b/src/s3ql/backends/gs.py
@@ -444,6 +444,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
             raise _map_request_error(exc, key) or exc
         self._parse_json_response(resp)
 
+    @retry
     @copy_ancestor_docstring
     def update_meta(self, key, metadata):
 


### PR DESCRIPTION
I think the `update_meta` method of the Google Storage backend is missing a `@retry` annotation. The S3, Swift and B2 backends delegate `update_meta` to `copy` and thus their `update_meta` methods do not need the `@retry` annotation but the gs backend makes the API call directly and would benefit from the `@retry` annotation to make the gs backend more resilient against temporary errors.
