### PR TITLE
B2: Handle backend options type conversions

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,8 @@
+UNRELEASED CHANGES
+
+  * The tcp-timeout backend option of the B2 Backend works now.
+
+
 2021-01-03, S3Ql 3.7.0
 
   * S3QL now requires Python 3.7 or newer.

--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -58,17 +58,17 @@ class B2Backend(AbstractBackend, metaclass=ABCDocstMeta):
         self.b2_application_key_id = options.backend_login
         self.b2_application_key = options.backend_password
 
-        self.tcp_timeout = self.options.get('tcp-timeout', 20)
+        self.tcp_timeout = int(self.options.get('tcp-timeout', 20))
 
         self.account_id = None
 
-        self.disable_versions = self.options.get('disable-versions', False)
-        self.retry_on_cap_exceeded = self.options.get('retry-on-cap-exceeded', False)
+        self.disable_versions = 'disable-versions' in self.options
+        self.retry_on_cap_exceeded = 'retry-on-cap-exceeded' in self.options
 
         # Test modes
-        self.test_mode_fail_some_uploads = self.options.get('test-mode-fail-some-uploads', False)
-        self.test_mode_expire_some_tokens = self.options.get('test-mode-expire-some-tokens', False)
-        self.test_mode_force_cap_exceeded = self.options.get('test-mode-force-cap-exceeded', False)
+        self.test_mode_fail_some_uploads = 'test-mode-fail-some-uploads' in self.options
+        self.test_mode_expire_some_tokens = 'test-mode-expire-some-tokens' in self.options
+        self.test_mode_force_cap_exceeded = 'test-mode-force-cap-exceeded' in self.options
 
         (bucket_name, prefix) = self._parse_storage_url(options.storage_url, self.ssl_context)
         self.bucket_name = bucket_name


### PR DESCRIPTION
The B2 backend did not do type conversion of the backend options that user provided (they need to be converted from string to the desired type). 

It is only a problem for the `tcp-timeout` option since all other are boolean flags only. But I took the liberty to change the other options to a `'option-name' in options` style. Otherwise a backend option like this `--backend-options disable-versions=` would not activate the `disable-versions` option (since an empty string is falsy).

Fixes #237