### PR TITLE
Fix upload thread creation timing issue

### DIFF
--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -204,7 +204,6 @@ async def main_async(options, stdout_log_handler):
       async with AsyncExitStack() as cm:
         block_cache = BlockCache(backend_pool, db, cachepath + '-cache',
                                  options.cachesize * 1024, options.max_cache_entries)
-        block_cache.init(options.threads)
         cm.push_async_callback(block_cache.destroy, options.keep_cache)
 
         operations = fs.Operations(block_cache, db, max_obj_size=param['max_obj_size'],
@@ -239,6 +238,8 @@ async def main_async(options, stdout_log_handler):
             daemonize(options.cachedir)
 
         mark_metadata_dirty(backend, cachepath, param)
+
+        block_cache.init(options.threads)
 
         nursery.start_soon(metadata_upload_task.run, name='metadata-upload-task')
         cm.callback(metadata_upload_task.stop)


### PR DESCRIPTION
If the block cache is initialised (i.e. associated threads created, with
references to trio channels) before daemonisation, those threads end up
running in a separate process to the main trio code and thus
sending/receiving on two unrelated/"disconnected" channels.

Fix this by moving initialisation back after daemonisation, as was the
case before the commit in fbd3116.