### PR TITLE
Disable packaging S3QL into a ZIP egg.

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -3,6 +3,8 @@ Unreleased Changes
   * Fixed a crash with `dugong.StateError` in the Google Storage backend when the
     authentication token expires in the middle of an upload.
 
+  * S3QL is compatible with newer setuptools (>=47)
+
 
 2021-03-07, S3QL 3.7.1
 

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ def main():
 
     setuptools.setup(
           name='s3ql',
-          zip_safe=True,
+          zip_safe=False,
           version=s3ql.VERSION,
           description='a full-featured file system for online data storage',
           long_description=long_desc,


### PR DESCRIPTION
S3QL bundled with newer setuptools cannot find its deltadump*.so file that gets bundled inside the ZIP file.

This is the easiest solution: just do not use a ZIP file but an egg directory.

Fixes #242 (tested), #193 (suspected)