### PR TITLE
Modify check for access to drop_caches

### DIFF
--- a/tests/t5_cp.py
+++ b/tests/t5_cp.py
@@ -73,8 +73,13 @@ class TestCp(t4_fuse.TestFuse):
 
 
     def test_cp_inode_invalidate(self):
-        if os.getuid() != 0:
-            pytest.skip('test_cp_inode_invalidate requires root, skipping.')
+        # check if we can write to drop_caches
+        try:
+            with open("/proc/sys/vm/drop_caches", "w") as drop_caches:
+                if not drop_caches.writeable():
+                    raise OsError.PermissionError('drop_caches not writable')
+        except OSError:
+            pytest.skip('test_cp_inode_invalidate requires drop_caches to be writable, skipping.')
 
         self.passphrase = None
         self.mkfs()

--- a/tests/t5_cp.py
+++ b/tests/t5_cp.py
@@ -76,8 +76,7 @@ class TestCp(t4_fuse.TestFuse):
         # check if we can write to drop_caches
         try:
             with open("/proc/sys/vm/drop_caches", "w") as drop_caches:
-                if not drop_caches.writeable():
-                    raise OsError.PermissionError('drop_caches not writable')
+                pass
         except OSError:
             pytest.skip('test_cp_inode_invalidate requires drop_caches to be writable, skipping.')
 


### PR DESCRIPTION
Change test to check that drop_caches is writable, rather than just for
root. This is more specific and allows tests in containers or other
scenarios where running as uid 0 doesn't automatically mean drop_caches is
writable to skip the test