### PR TITLE
Wasabi - Add TemporarilyUnavailable to list of allowed errors to be retried

### DIFF
--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -143,7 +143,8 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
 
         if isinstance(exc, (InternalError, BadDigestError, IncompleteBodyError,
                             RequestTimeoutError, OperationAbortedError,
-                            SlowDownError, ServiceUnavailableError)):
+                            SlowDownError, ServiceUnavailableError,
+                            TemporarilyUnavailableError)):
             return True
 
         elif is_temp_network_error(exc):
@@ -1034,5 +1035,6 @@ class OperationAbortedError(S3Error): pass
 class RequestTimeoutError(S3Error): pass
 class SlowDownError(S3Error): pass
 class ServiceUnavailableError(S3Error): pass
+class TemporarilyUnavailableError(S3Error): pass
 class RequestTimeTooSkewedError(S3Error): pass
 class NoSuchBucketError(S3Error, DanglingStorageURLError): pass


### PR DESCRIPTION
This is the specific error I get when connected to Wasabi (happens sporadily, sometimes after a lot of uploads):

```
2021-11-08 16:41:19.662 1308757:Thread-2 root.excepthook: Uncaught top-level exception:
Traceback (most recent call last):
  File "/root/src/s3ql/src/s3ql/mount.py", line 58, in run_with_except_hook
    run_old(*args, **kw)
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/root/src/s3ql/src/s3ql/block_cache.py", line 319, in _upload_loop
    self._do_upload(*tmp)
  File "/root/src/s3ql/src/s3ql/block_cache.py", line 384, in _do_upload
    obj_size = backend.perform_write(do_write, 's3ql_data_%d'
  File "/root/src/s3ql/src/s3ql/backends/common.py", line 108, in wrapped
    return method(*a, **kw)
  File "/root/src/s3ql/src/s3ql/backends/common.py", line 279, in perform_write
    return fn(fh)
  File "/root/src/s3ql/src/s3ql/backends/comprenc.py", line 389, in __exit__
    self.close()
  File "/root/src/s3ql/src/s3ql/backends/comprenc.py", line 383, in close
    self.fh.close()
  File "/root/src/s3ql/src/s3ql/backends/comprenc.py", line 548, in close
    self.fh.close()
  File "/root/src/s3ql/src/s3ql/backends/common.py", line 108, in wrapped
    return method(*a, **kw)
  File "/root/src/s3ql/src/s3ql/backends/s3c.py", line 912, in close
    self.headers['Content-Type'] = 'application/octet-stream'
  File "/root/src/s3ql/src/s3ql/backends/s3c.py", line 531, in _do_request
    # Error
  File "/root/src/s3ql/src/s3ql/backends/s3c.py", line 565, in _parse_error_response
s3ql.backends.s3c.S3Error: TemporarilyUnavailable: Storage service is temporarily not available.  Please try again later (name: UnexpectedError | detail: ConnWaitError)
```

That looks like a temporarily error to me, and nothing to throw a big fatal about. Unfortunately, it's not caught, and whenever this happens it throws the entire mount down the drain, unmounting it and all.

This PR introduces the error to be handled as part of `is_temp_failure` check.

Admittedly, this is a Wasabi-centric error. Unsure if this is standard S3 error code.

To be tested against my Wasabi bucket once I can do that again, in the meanwhile, I'm not a python dev so please look over this PR carefully thank you.