### PR TITLE
Issue 260, close() after truncate() size fix, fsck fix

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,17 @@
+2021-11-29
+
+  * Fix for fsck.s3ql removing .tmp files in cache directory.
+  
+  * Fix bug that would cause incorrect size to be recorded for a block
+    if the file had zero-bytes added to the end by using truncate followed
+    by close.  (The recorded size does not count the zero bytes.)  Both rsync's
+    -S (sparse) option and VirtualBox do this for example. No data corruption,
+    but contrib/fixup_block_sizes.py should be run to fix this.
+    
+  * contrib/fix_block_sizes.py updated to check all block sizes, not just
+    ones with size multiple of 512, so it detects blocks affected by this
+    bug.
+
 2021-11-07, S3QL 3.8.0
 
   * The way to build the documentation has changed. Instead of running

--- a/contrib/fix_block_sizes.py
+++ b/contrib/fix_block_sizes.py
@@ -132,9 +132,6 @@ def fix_block(obj_id, block_id, cur_size, db, backend):
      when this happens and correct the block size instead of the file size.
     '''
 
-    if cur_size % 512 != 0:
-        return False
-
     act_size = None
     def do_read(fh):
         nonlocal act_size

--- a/src/s3ql/block_cache.py
+++ b/src/s3ql/block_cache.py
@@ -93,9 +93,8 @@ class CacheEntry(object):
         self.dirty = True
         self.fh.truncate(size)
         if size is None:
-            if self.pos != self.size:
-                self.size = self.pos
-        elif size != self.size:
+            self.size = self.pos
+        else:
             self.size = size
 
     def write(self, buf):

--- a/src/s3ql/block_cache.py
+++ b/src/s3ql/block_cache.py
@@ -93,9 +93,9 @@ class CacheEntry(object):
         self.dirty = True
         self.fh.truncate(size)
         if size is None:
-            if self.pos < self.size:
+            if self.pos != self.size:
                 self.size = self.pos
-        elif size < self.size:
+        elif size != self.size:
             self.size = size
 
     def write(self, buf):

--- a/src/s3ql/fsck.py
+++ b/src/s3ql/fsck.py
@@ -198,11 +198,12 @@ class Fsck(object):
             if match:
                 inode = int(match.group(1))
                 blockno = int(match.group(2))
-            elif re.match(r'^(\\d+)-(\\d+)\.tmp$', filename):
+            elif re.match('^(\\d+)-(\\d+)\\.tmp$', filename):
                 # Temporary file created when downloading object
                 self.found_errors = True
                 self.log_error("Removing leftover temporary file: " + filename)
                 os.unlink(os.path.join(self.cachedir, filename))
+                continue
             else:
                 raise RuntimeError('Strange file in cache directory: %s' % filename)
 


### PR DESCRIPTION
This fixes issue 260 (fix_block_sizes.py should scan all blocks, not just multiples of 512); a second bug causing non-matching block.size and real size if truncate() was called to extend a file, then no further writes before it's close()'ed; and a fsck patch so that it deletes .tmp files in s3ql cache as intended.
Thanks!
--Henry