### PR TITLE
remove empty s3ql data directories

### DIFF
--- a/src/s3ql/backends/local.py
+++ b/src/s3ql/backends/local.py
@@ -57,7 +57,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
     def is_temp_failure(self, exc): #IGNORE:W0613
         #Possible race if os.rmdir in delete runs in between
         #ObjectW os.makedirs and open(), retry if this happens.
-        if isinstance(exc, FileNotFoundError)
+        if isinstance(exc, FileNotFoundError):
             return True
         return False
 

--- a/src/s3ql/backends/local.py
+++ b/src/s3ql/backends/local.py
@@ -55,6 +55,10 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
 
     @copy_ancestor_docstring
     def is_temp_failure(self, exc): #IGNORE:W0613
+        #Possible race if os.rmdir in delete runs in between
+        #ObjectW os.makedirs and open(), retry if this happens.
+        if isinstance(exc, FileNotFoundError)
+            return True
         return False
 
     @copy_ancestor_docstring
@@ -140,6 +144,10 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
                 pass
             else:
                 raise NoSuchObject(key)
+        try:
+            os.rmdir(os.path.dirname(path))
+        except OSError:
+            pass
 
     @copy_ancestor_docstring
     def list(self, prefix=''):

--- a/tests/t1_backends.py
+++ b/tests/t1_backends.py
@@ -188,7 +188,10 @@ def yield_local_backend(bi):
         yield backend
     finally:
         backend.close()
-        shutil.rmtree(backend_dir)
+        try:
+            shutil.rmtree(backend_dir)
+        except OSError:
+            pass
 
 def yield_mock_backend(bi):
     backend_class = backends.prefix_map[bi.classname]

--- a/tests/t3_fsck.py
+++ b/tests/t3_fsck.py
@@ -435,12 +435,12 @@ class fsck_tests(unittest.TestCase):
         # Ensure that path exists
         objname = 's3ql_data_38375'
         self.backend[objname] = b'bla'
-        del self.backend[objname]
         path = self.backend._key_to_path(objname)
         tmpname = '%s#%d-%d.tmp' % (path, os.getpid(), _thread.get_ident())
         with open(tmpname, 'wb') as fh:
             fh.write(b'Hello, world')
-
+        del self.backend[objname]
+      
         self.assert_fsck(self.fsck.check_objects_temp)
 
     def test_obj_refcounts(self):

--- a/tests/t3_verify.py
+++ b/tests/t3_verify.py
@@ -36,7 +36,10 @@ def backend():
         yield backend
     finally:
         backend.close()
-        shutil.rmtree(backend_dir)
+        try:
+            shutil.rmtree(backend_dir)
+        except OSError:
+            pass
 
 @pytest.yield_fixture()
 def db():

--- a/tests/t4_adm.py
+++ b/tests/t4_adm.py
@@ -101,7 +101,7 @@ class AdmTests(unittest.TestCase):
             plain_backend = local.Backend(Namespace(
                 storage_url=self.storage_url))
             assert list(plain_backend.list()) == []
-        except s3ql.backends.common.DanglingStorageError:
+        except DanglingStorageError:
             pass
 
 

--- a/tests/t4_adm.py
+++ b/tests/t4_adm.py
@@ -15,6 +15,7 @@ if __name__ == '__main__':
 from s3ql.backends import local
 from s3ql.backends.comprenc import ComprencBackend
 from s3ql.backends.common import CorruptedObjectError
+from s3ql.backends.common import DanglingStorageURLError
 from argparse import Namespace
 import shutil
 import re

--- a/tests/t4_adm.py
+++ b/tests/t4_adm.py
@@ -34,8 +34,11 @@ class AdmTests(unittest.TestCase):
         self.passphrase = 'oeut3d'
 
     def tearDown(self):
-        shutil.rmtree(self.cache_dir)
-        shutil.rmtree(self.backend_dir)
+        try:
+            shutil.rmtree(self.cache_dir)
+            shutil.rmtree(self.backend_dir)
+        except OSError:
+            pass
 
     def mkfs(self):
         proc = subprocess.Popen(self.s3ql_cmd_argv('mkfs.s3ql') +

--- a/tests/t4_adm.py
+++ b/tests/t4_adm.py
@@ -92,10 +92,17 @@ class AdmTests(unittest.TestCase):
         print('yes', file=proc.stdin)
         proc.stdin.close()
         self.assertEqual(proc.wait(), 0)
-
-        plain_backend = local.Backend(Namespace(
-            storage_url=self.storage_url))
-        assert list(plain_backend.list()) == []
+        
+        #With directory removal patch, the storage directory is removed
+        #when s3qladm clears the FS.  Having the backend fail here with
+        #DanglingStorageError still indicates the FS was cleared as it
+        #should be.
+        try:
+            plain_backend = local.Backend(Namespace(
+                storage_url=self.storage_url))
+            assert list(plain_backend.list()) == []
+        except s3ql.backends.common.DanglingStorageError:
+            pass
 
 
     def test_key_recovery(self):

--- a/tests/t4_adm.py
+++ b/tests/t4_adm.py
@@ -101,7 +101,7 @@ class AdmTests(unittest.TestCase):
             plain_backend = local.Backend(Namespace(
                 storage_url=self.storage_url))
             assert list(plain_backend.list()) == []
-        except DanglingStorageError:
+        except DanglingStorageURLError:
             pass
 
 


### PR DESCRIPTION
I found over time my s3ql_data_ directory had many man empty directories -- 100,000s of them.  This patch will attempt to remove the storage directory when a block is deleted; if the directory is empty, it removes the directory successfully; if it's not empty, the os.rmdir returns an error which is harmlessly trapped; if it's empty but a race condition means something was going to put a file in there (.. if that's possible) it throws a "FileNotFoundError", I set this to be treated as a temporary error, so it'll treat it just like S3 etc. not taking a block and retry it. 

I had a huge reduction in fsck.s3ql run time, on one (spinning rust) drive it cut my time from 3 or 4 hours to about 10 minutes.  Besides the obvious speedup of not having to walk through in my case about 800,000 empty directories (about 90% of the total), I also had additional speedup because the directory tree metadata now fits in Linux VFS cache whereas before it wasn't even close.

To clean my s3ql-data I just changed into the s3ql-data/ directory and ran "find -type d -exec rmdir -p {} \+", which took rather a long time (I ran it overnight..) but cleaned it out nicely.  That is probably not safe to run on a live filesystem with existing s3ql but would be with this one since any "rmdir race" will be treated as a retryable temporary error.
Thanks
--Henry