### PR TITLE
Add special handling for sqlite bug that can make fsck.s3ql corrupt its database

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -15,6 +15,11 @@ UNRELEASED CHANGES
     object. However, this feature was never implemented. The necessary abstraction layer
     has now been removed, which should increase performance and reduce database size.
 
+  * Workarounds for bugs in sqlite 3.38.0 – 3.38.4.
+
+    Sqlite 3.38 introduced bloom filter optimizations. The first patch releases of sqlite 3.38
+    had some bugs that prevented fsck.s3ql from running properly and made it corrupt the database.
+
 
 2022-01-10, S3QL 3.8.1
 

--- a/tests/t3_fsck.py
+++ b/tests/t3_fsck.py
@@ -131,6 +131,14 @@ class fsck_tests(unittest.TestCase):
 
         self.assert_fsck(self.fsck.check_lof)
 
+    def test_lof_issue_273(self):
+        name_id = self.db.get_val('SELECT id FROM names WHERE name=?', (b'lost+found',))
+        inode = self.db.get_val('SELECT inode FROM contents WHERE name_id=? AND '
+                                'parent_inode=?', (name_id, ROOT_INODE))
+        self.db.execute('UPDATE contents SET parent_inode = ? WHERE inode = ?', (inode, inode))
+
+        self.assert_fsck(self.fsck.check_lof)
+
     def test_wrong_inode_refcount(self):
 
         inode = self.db.rowid("INSERT INTO inodes (mode,uid,gid,mtime_ns,atime_ns,ctime_ns,refcount,size) "


### PR DESCRIPTION
The workaround is from https://sqlite.org/forum/forumpost/4c490f2150a8ba73 – I could not make the easier method of just disabling the bloom filter optimization work (`.testctrl optimizations 0x80000`) since `apsw` does not provide access to `sqlite3_test_control`.

This PR also adds a fix that should automatically repair a database that a previous version of `fsck.s3ql` has corrupted.

Fixes #273, #274