### PR TITLE
s3c backend: fix handling of HTTP 429 and missing Content-Type header

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -20,6 +20,12 @@ UNRELEASED CHANGES
     Sqlite 3.38 introduced bloom filter optimizations. The first patch releases of sqlite 3.38
     had some bugs that prevented fsck.s3ql from running properly and made it corrupt the database.
 
+  * Fix handling of rate-limits and responses without Content-Type header
+
+    Some Non-Amazon S3 providers return HTTP 429 when rate-limiting.
+    Additionally, error responses may occasionally come without a Content-Type header.
+    These are now handled, no longer causing file system crashes.
+
 
 2022-01-10, S3QL 3.8.1
 

--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -547,7 +547,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
             raise HTTPError(resp.status, resp.reason, resp.headers)
 
         # If not XML, do the best we can
-        if not (isinstance(content_type, str) and XML_CONTENT_RE.match(content_type)) or resp.length == 0:
+        if content_type is None or resp.length == 0 or not XML_CONTENT_RE.match(content_type):
             self.conn.discard()
             raise HTTPError(resp.status, resp.reason, resp.headers)
 

--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -152,11 +152,11 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
         # codes where retry is definitely not desired. For 4xx (client error) we
         # do not retry in general, but for 408 (Request Timeout) RFC 2616
         # specifies that the client may repeat the request without
-        # modifications.
+        # modifications. We also retry on 429 (Too Many Requests).
         elif (isinstance(exc, HTTPError) and
               ((500 <= exc.status <= 599
                 and exc.status not in (501,505,508,510,511,523))
-               or exc.status == 408)):
+               or exc.status in (408,429))):
             return True
 
         # Consider all SSL errors as temporary. There are a lot of bug


### PR DESCRIPTION
The first commit has already been the case for Swift and B2 backends. It is likely this has gone unnoticed for a while as Amazon S3 sends **503** when rate-limiting, while other S3-compatible providers send the technically more correct **429**.

On parsing error response, check if the content-type header is a string at all. In some situations (such as rate-limits by non-Amazon S3 providers), it isn't even set anymore. This is fixed in the second commit.

Fixes issue #276 and #278.