### PR TITLE
s3c: Add type check to _parse_error_response()

### DIFF
--- a/src/s3ql/backends/s3c.py
+++ b/src/s3ql/backends/s3c.py
@@ -547,7 +547,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
             raise HTTPError(resp.status, resp.reason, resp.headers)
 
         # If not XML, do the best we can
-        if not XML_CONTENT_RE.match(content_type) or resp.length == 0:
+        if not (isinstance(content_type, str) and XML_CONTENT_RE.match(content_type)) or resp.length == 0:
             self.conn.discard()
             raise HTTPError(resp.status, resp.reason, resp.headers)
 


### PR DESCRIPTION
On parsing error response, check if the `content-type` header is a string at all. In some situations (such as rate-limits by third-party providers), it isn't even set anymore.