### PR TITLE
Make ci-prepare-dist.sh independent

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: 'sudo apt-get update'
-      - run: tests/ci-prepare-${{ matrix.deps }}.sh ${{ matrix.os }}
+      - run: tests/ci-prepare-${{ matrix.deps }}.sh
       - run: python3 setup.py build_cython
       - run: python3 setup.py build_ext --inplace
       - run: python3 -m pytest -r s tests/

--- a/tests/ci-prepare-dist.sh
+++ b/tests/ci-prepare-dist.sh
@@ -23,7 +23,7 @@ sudo apt install -y \
 
 # The python3-attr that is shipped with Ubuntu 20.04 is incompatible
 # with python3-trio. *sigh*
-if [ "${os}" = "Ubuntu-22.04" ]; then
+if [ "${os}" = "Ubuntu-20.04" ]; then
     sudo python3 -m pip install "attrs >= 20.1.0, < 21.0.0 "
 else
     sudo apt install -y python3-attr
@@ -34,7 +34,7 @@ fi
 sudo python3 -m pip install \
      "pytest_trio == 0.6.0"
 
-if [ "${os}" = "Ubuntu-22.04" ]; then
+if [ "${os}" = "Ubuntu-20.04" ]; then
     sudo apt install -y \
          python3-dugong
     sudo python3 -m pip install \

--- a/tests/ci-prepare-dist.sh
+++ b/tests/ci-prepare-dist.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-os="$1"
+os="$(lsb_release --short --id)-$(lsb_release --short --release)"
 
 sudo apt install -y \
      cython3 \
@@ -23,7 +23,7 @@ sudo apt install -y \
 
 # The python3-attr that is shipped with Ubuntu 20.04 is incompatible
 # with python3-trio. *sigh*
-if [ "${os}" = "ubuntu-20.04" ]; then
+if [ "${os}" = "Ubuntu-22.04" ]; then
     sudo python3 -m pip install "attrs >= 20.1.0, < 21.0.0 "
 else
     sudo apt install -y python3-attr
@@ -34,7 +34,7 @@ fi
 sudo python3 -m pip install \
      "pytest_trio == 0.6.0"
 
-if [ "${os}" = "ubuntu-20.04" ]; then
+if [ "${os}" = "Ubuntu-22.04" ]; then
     sudo apt install -y \
          python3-dugong
     sudo python3 -m pip install \

--- a/tests/ci-prepare-latest.sh
+++ b/tests/ci-prepare-latest.sh
@@ -30,7 +30,7 @@ sudo ldconfig
 
 # Upgrading cryptography results in an AttributeError in OpenSSL/crypto.py. My
 # guess is that this is due to a non-declared version dependency on OpenSSL.
-if [ "${os}" = "Ubuntu-22.04" ]; then
+if [ "${os}" = "Ubuntu-20.04" ]; then
     sudo apt install -y \
          python3-cryptography
 else

--- a/tests/ci-prepare-latest.sh
+++ b/tests/ci-prepare-latest.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-os="$1"
+os="$(lsb_release --short --id)-$(lsb_release --short --release)"
 
 sudo apt install -y \
      libsqlite3-dev \
@@ -30,7 +30,7 @@ sudo ldconfig
 
 # Upgrading cryptography results in an AttributeError in OpenSSL/crypto.py. My
 # guess is that this is due to a non-declared version dependency on OpenSSL.
-if [ "${os}" = "ubuntu-20.04" ]; then
+if [ "${os}" = "Ubuntu-22.04" ]; then
     sudo apt install -y \
          python3-cryptography
 else


### PR DESCRIPTION
No more necessary to pass these scripts the OS version.

Fails because of https://github.com/s3ql/s3ql/pull/293#issuecomment-1568268304