### PR TITLE
Draft: Bandwidth Alliance support for Backblaze

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,9 @@ Unreleased Changes
 * fsck.s3ql no longer attempts to verify unclean metadata backups, which
   in the past led to spurious warnings and crashes.
 
+* The Backblaze B2 backend has a new option `download-host-overwrite` to optionally
+  route all download requests through a proxy.
+
 
 S3QL 5.1.2 (2023-09-26)
 =======================

--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -434,7 +434,7 @@ are the following:
    controls if operations should be retried as cap counters are reset every day.
    Otherwise the exception would abort the program.
 
-.. option:: test_mode=<value>
+.. option:: test-mode=<value>
 
    This option puts the backblaze B2 server into test mode by adding a special header to the
    requests. Use this option only to test the failure resiliency of the backend implementation as it
@@ -453,6 +453,16 @@ are the following:
    Specifies the timeout used for TCP connections. If no data can be
    exchanged with the remote server for longer than this period, the
    TCP connection is closed and re-established (default: 20 seconds).
+
+.. option:: download-host-overwrite=<hostname>
+
+   If you specify this option all downloads will be routed thru this server (with HTTPS on port 443).
+   You can use this e.g. to download data thru a Cloudflare worker and benefit from the free bandwidth
+   agreement between B2 and Cloudflare (Bandwidth Alliance).
+
+   See
+   https://www.backblaze.com/docs/cloud-storage-deliver-private-backblaze-b2-content-through-cloudflare-cdn
+   for more information on how to set up the necessary Cloudflare worker.
 
 .. _Backblaze B2 API: https://www.backblaze.com/b2/docs/
 

--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -54,6 +54,7 @@ class B2Backend(AbstractBackend):
 
     known_options = {
         'disable-versions',
+        'download-host-overwrite',
         'retry-on-cap-exceeded',
         'test-mode',
         'tcp-timeout',
@@ -90,6 +91,7 @@ class B2Backend(AbstractBackend):
         # are set by _authorize_account
         self.api_url = None
         self.download_url = None
+        self.download_host_overwrite = self.options.get('download-host-overwrite', None)
         self.api_authorization_token = None
         self.api_connection = None
         self.download_connection = None
@@ -159,9 +161,10 @@ class B2Backend(AbstractBackend):
             self._authorize_account()
 
         if self.download_connection is None:
-            self.download_connection = HTTPConnection(
-                self.download_url.hostname, 443, ssl_context=self.ssl_context
-            )
+            hostname = self.download_url.hostname
+            if self.download_host_overwrite is not None:
+                hostname = self.download_host_overwrite
+            self.download_connection = HTTPConnection(hostname, 443, ssl_context=self.ssl_context)
             self.download_connection.timeout = self.tcp_timeout
 
         return self.download_connection


### PR DESCRIPTION
This PR adds a backend option for the Backblaze B2 backend that routes all download requests through a proxy server. This can be used to benefit from Backblaze's free egress to e.g. Cloudflare.

I do not have a Backblaze B2 or a Cloudflare Account with wich I could test this PR. We need someone to test this PR before we can merge it.


If this comment is still true we might get problems since the B2 backend does rely on the `Content-Size` header:
https://github.com/rclone/rclone/blob/ad83ff769b03b0731757431a596823822d12ae29/backend/b2/b2.go#L1831-L1837

Closes #333

 