### PR TITLE
Fix b2_backend.py

### DIFF
--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -515,8 +515,7 @@ class B2Backend(AbstractBackend):
             self.upload_connection = None
             raise
 
-        json_response = json.loads(response_body.decode('utf-8'))
-        return json_response
+        return len_
 
     def delete(self, key, force=False):
         log.debug('started with %s', key)


### PR DESCRIPTION
_write_fh() was returning an object (the server's json response) instead of the length of the blob stored