### PR TITLE
Document that S3QL needs at least Python 3.8

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+=======================
+
+* S3QL now needs Python 3.8+. Python 3.7 is end of life as of 2023-06-27.
+
 S3QL 5.1.3 (2023-12-08)
 =======================
 

--- a/rst/installation.rst
+++ b/rst/installation.rst
@@ -25,7 +25,7 @@ that is not the case.
 * `SQLite <http://www.sqlite.org/>`_ version 3.7.0 or newer. SQLite
   has to be installed as a *shared library* with development headers.
 
-* `Python <http://www.python.org/>`_ 3.7 or newer. Make sure to also
+* `Python <http://www.python.org/>`_ 3.8 or newer. Make sure to also
   install the development headers.
 
 * The following Python modules:

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ def main():
         'trio >= 0.15',
         'pyfuse3 >= 3.2.0, < 4.0',
     ]
-    if sys.version_info < (3, 7, 0):
-        required_pkgs.append('async_generator')
 
     setuptools.setup(
         name='s3ql',
@@ -145,6 +143,7 @@ def main():
         },
         install_requires=required_pkgs,
         tests_require=['pytest >= 3.7'],
+        python_requires='>=3.8',
         cmdclass={'upload_docs': upload_docs, 'build_cython': build_cython, 'pytest': pytest},
     )
 


### PR DESCRIPTION
The dugong tests use [PEP-570](https://peps.python.org/pep-0570/) Syntax 

see
https://github.com/s3ql/s3ql/blob/efd20a222a1032ea5baf7f0069bc010c97373698/tests/t0_http.py#L405

thus S3QL technically needs at least Python 3.8 (to run the tests). Since Python 3.7 is end-of-life anyway, this PR just documents that S3QL needs at least Python 3.8.