### PR TITLE
Remove (undocumented) packaging dependency

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,9 @@ UNRELEASED
 
 * S3QL now needs Python 3.8+. Python 3.7 is end of life as of 2023-06-27.
 
+* S3QL does not depend on packaging anymore. It was an undocumented dependency for
+  a simple version compare of the Swift backend. This compare is not necessary anymore.
+
 S3QL 5.1.3 (2023-12-08)
 =======================
 

--- a/src/s3ql/database.py
+++ b/src/s3ql/database.py
@@ -162,7 +162,6 @@ class Connection:
             'PRAGMA recursize_triggers = on',
             'PRAGMA temp_store = FILE',
             'PRAGMA legacy_file_format = off',
-
             # Read performance decreases linearly with increasing WAL size, so we do not
             # want the WAL to grow too much. However, every checkpointing operation requires
             # fsync(), so we can speed up writes by having them as rarely as possible.


### PR DESCRIPTION
It was used to detect a Swift server that has a special COPY operation (for server side copy). After backend refactorings S3QL does not do explicit copies anymore and cannot use the server side copy optimization. That's why we can just remove the whole version check and detection of this feature.

Closes #346
