### PR TITLE
Fix tests for Python 3.12

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-20.04
             deps: latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: 'sudo apt-get update'
       - run: python3 -m venv venv --system-site-packages
       - run: tests/ci-prepare-${{ matrix.deps }}.sh
@@ -39,6 +39,6 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo python3 -m pip install "black == 23.3.0"
       - run: black --line-length=100 --skip-string-normalization --check --diff --color --required-version 23.3.0 .

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -34,6 +34,7 @@ jobs:
       - run: venv/bin/python setup.py build_cython
       - run: venv/bin/python setup.py build_ext --inplace
       - run: venv/bin/python -m pytest -r s tests/
+      - run: venv/bin/pip install sphinx
       - run: '. venv/bin/activate && ./build_docs.sh'
   check-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,19 +15,26 @@ jobs:
   build:
     runs-on: '${{ matrix.os }}'
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-20.04
-          - ubuntu-latest
+          - ubuntu-22.04
+          - ubuntu-24.04
         deps: [ dist, latest ]
+        exclude:
+          # gets error 'Fatal Python error: Cannot recover from stack overflow.' in tests
+          - os: ubuntu-20.04
+            deps: latest
     steps:
       - uses: actions/checkout@v3
       - run: 'sudo apt-get update'
+      - run: python3 -m venv venv --system-site-packages
       - run: tests/ci-prepare-${{ matrix.deps }}.sh
-      - run: python3 setup.py build_cython
-      - run: python3 setup.py build_ext --inplace
-      - run: python3 -m pytest -r s tests/
-      - run: ./build_docs.sh
+      - run: venv/bin/python setup.py build_cython
+      - run: venv/bin/python setup.py build_ext --inplace
+      - run: venv/bin/python -m pytest -r s tests/
+      - run: '. venv/bin/activate && ./build_docs.sh'
   check-style:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -19,5 +19,5 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: crate-ci/typos@master

--- a/src/s3ql/backends/comprenc.py
+++ b/src/s3ql/backends/comprenc.py
@@ -6,7 +6,6 @@ Copyright © 2008 Nikolaus Rath <Nikolaus@rath.org>
 This work can be distributed under the terms of the GNU GPLv3.
 '''
 
-from ast import Bytes
 import bz2
 import hashlib
 import hmac
@@ -32,7 +31,7 @@ HMAC_SIZE = 32
 crypto_backend = crypto_backends.default_backend()
 
 
-def sha256(s: Bytes) -> Bytes:
+def sha256(s: bytes) -> bytes:
     return hashlib.sha256(s).digest()
 
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,12 @@
 # This is not a general purpose Dockerfile
 # It's tailored for running tests and building documentation.
 
-FROM ubuntu:focal AS build
+FROM ubuntu:jammy AS build
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \
- && apt-get install -y fakeroot curl dpkg-dev build-essential manpages pbuilder aptitude rsync \
+ && apt-get install -y lsb-release sudo curl build-essential manpages \
                        git libbz2-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev \
                        zlib1g-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils libxml2-dev libxmlsec1-dev liblzma-dev \
                        libsystemd-dev gcc psmisc pkg-config libattr1-dev libsqlite3-dev libjs-sphinxdoc texlive-latex-base \
@@ -17,7 +17,7 @@ RUN apt-get update \
  && pip install "setuptools >= 40.3.0"
 
 ADD tests/ci-prepare-latest.sh /ci-prepare-latest.sh
-RUN /ci-prepare-latest.sh ubuntu-20.04
+RUN /ci-prepare-latest.sh ubuntu-22.04
 
 ADD . /build
 WORKDIR /build

--- a/tests/ci-prepare-dist.sh
+++ b/tests/ci-prepare-dist.sh
@@ -24,7 +24,6 @@ sudo apt install -y \
      python3-pip \
      python3-pytest \
      python3-requests \
-     python3-sphinx \
      python3-trio
 
 # The python3-attr that is shipped with Ubuntu 20.04 is incompatible

--- a/tests/ci-prepare-dist.sh
+++ b/tests/ci-prepare-dist.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+PIP="sudo python3 -m pip"
+if [ -f venv/bin/activate ]; then
+  . venv/bin/activate
+  PIP="pip"
+fi
+
 os="$(lsb_release --short --id)-$(lsb_release --short --release)"
 
 sudo apt install -y \
@@ -24,18 +30,21 @@ sudo apt install -y \
 # The python3-attr that is shipped with Ubuntu 20.04 is incompatible
 # with python3-trio. *sigh*
 if [ "${os}" = "Ubuntu-20.04" ]; then
-    sudo python3 -m pip install "attrs >= 20.1.0, < 21.0.0 "
+    $PIP install "attrs >= 20.1.0, < 21.0.0 "
 else
     sudo apt install -y python3-attr
 fi
 
 
 # Where packages are not available, download from pypi instead (but pin to specific versions).
-sudo python3 -m pip install \
-     "pytest_trio == 0.6.0"
+if [ "${os}" = "Ubuntu-24.04" ]; then
+  sudo apt install -y python3-pytest-trio
+else
+  $PIP install "pytest_trio == 0.6.0"
+fi
 
 if [ "${os}" = "Ubuntu-20.04" ]; then
-    sudo python3 -m pip install \
+    $PIP install \
          "pyfuse3 >= 3.2.0, < 4.0" \
          "google-auth-oauthlib >= 0.4.0, < 0.5.0"
 else
@@ -47,4 +56,4 @@ fi
 echo "Current libsqlite3-dev version: $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"
 
 echo "Installed PIP versions:"
-python3 -m pip freeze
+$PIP freeze

--- a/tests/ci-prepare-latest.sh
+++ b/tests/ci-prepare-latest.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+PIP="sudo python3 -m pip"
+PIP_ARGS=("--upgrade" "--upgrade-strategy" "eager")
+if [ -f venv/bin/activate ]; then
+  . venv/bin/activate
+  PIP="pip"
+fi
+
 os="$(lsb_release --short --id)-$(lsb_release --short --release)"
 
 sudo apt install -y \
@@ -31,14 +38,12 @@ sudo ldconfig
 # Upgrading cryptography results in an AttributeError in OpenSSL/crypto.py. My
 # guess is that this is due to a non-declared version dependency on OpenSSL.
 if [ "${os}" = "Ubuntu-20.04" ]; then
-    sudo apt install -y \
-         python3-cryptography
+    sudo apt install -y python3-cryptography
 else
-    sudo python3 -m pip install --upgrade --upgrade-strategy eager \
-         cryptography
+    $PIP install "${PIP_ARGS[@]}" cryptography
 fi
 
-sudo python3 -m pip install --upgrade --upgrade-strategy eager \
+$PIP install "${PIP_ARGS[@]}" \
      apsw \
      attrs \
      cython \
@@ -55,4 +60,4 @@ sudo python3 -m pip install --upgrade --upgrade-strategy eager \
 echo "Current libsqlite3-dev version: $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"
 
 echo "Installed PIP versions:"
-python3 -m pip freeze
+$PIP freeze

--- a/tests/ci-prepare-latest.sh
+++ b/tests/ci-prepare-latest.sh
@@ -54,7 +54,6 @@ $PIP install "${PIP_ARGS[@]}" \
      pytest \
      pytest_trio \
      requests \
-     sphinx \
      trio
 
 echo "Current libsqlite3-dev version: $(dpkg-query --show --showformat='${Version}' libsqlite3-dev)"

--- a/tests/t0_http.py
+++ b/tests/t0_http.py
@@ -289,7 +289,6 @@ def test_connect_proxy(http_server, monkeypatch, test_port):
 
     # We don't *actually* want to establish SSL, that'd be
     # to complex for our mock server
-    monkeypatch.setattr('ssl.match_hostname', lambda x, y: True)
     conn = HTTPConnection(
         test_host,
         test_port,


### PR DESCRIPTION
`ssl.match_hostname` is not used anymore for hostname verification since Python 3.7 (See https://docs.python.org/3/library/ssl.html#verifying-certificates). So monkey patching it should not be needed anymore.

This monkey patch failes with Python 3.12 since it lookls like `ssl.match_hostname` was completly removed in this version of Python.

Since the test in Ubuntu 20.04 (focal) fail (see e.g. https://github.com/s3ql/s3ql/actions/runs/8906866788/job/24459714843#step:7:388 ) this PR also switches over to Ubuntu 22.04 (jammy) for the `tests/run-tests-via-docker.sh` script and it also excludes it from the CI pipeline.

This PR also refactors the CI pipeline to use an venv. Python 3.12 on Ubunut 24.04 does not allow to install/upgrade pip packages when the package was already installed via the package manager.


**Note**: The matrix now explicitly uses versioned ubuntu runners (ubunut-20.04, ubuntu-22.04, ubuntu-24.04) Thus the status check needs to be updated to use e.g. `build (ubuntu-24.04, dist)` in the [branch settings](https://github.com/s3ql/s3ql/settings/branches).