### PR TITLE
http: Make S3QL's HTTP client library more forgiving

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,4 +1,10 @@
-S3QL 3.2.1 (2024-07-05)
+UNRELEASED
+======================
+
+* Make S3QL's HTTP client library more forgiving when HTTP servers do not behave according to HTTP/1.1 specification.
+  This will make filesystems with OVHcloud's OpenStack Swift implementation more robust.
+
+S3QL 5.2.1 (2024-07-05)
 ======================
 
 * Fixed a crash with `TypeError: CacheEntry.seek() takes 2 positional arguments


### PR DESCRIPTION
This solution to #355 will not shadow any client side bugs and just works without any backend options.

Turns out that the special case for the 408 request timeout errors I included in #361 is not needed (anymore). The only thing that this PR adds is the ability to recover gracefully from an HTTP server response without a `Content-Length` header that also does not have a `Connection: close` header present. We will just assume that the server sent a `Connection: close` in this case.

I also added two tests that confirm that the HTTP client library can handle unsolicited 408 Request timeout responses.

Fixes #355 