### PR TITLE
Require Cython to be at least version 3.0.0 to be compatible with Python 3.12

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+UNRELEASED
+=======================
+
+* Make release tarballs compatible with Python 3.12 by using a newer Cython version
+  to generate the necessary C++ extension.
+
 S3QL 5.2.2 (2024-09-01)
 =======================
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -14,6 +14,12 @@ echo "Creating release tarball for ${TAG}..."
 
 git checkout -q "${TAG}"
 
+# check if we have a recent enough Cython version so that the release tarball is compatible with Python 3.12
+if ! python3 -c 'import sys; from Cython.Compiler.Version import version as cython_version; sys.exit(1) if tuple(map(int, (cython_version.split(".")[0:3]))) < (3, 0, 0) else sys.exit(0)'; then
+  printf "You need to install Cython >= 3.0.0. You have version %s installed\n" "$(python3 -c 'from Cython.Compiler.Version import version as cython_version; print(cython_version)')"
+  exit 1
+fi
+
 python3 setup.py build_cython build_ext --inplace
 ./build_docs.sh
 (cd doc/pdf && latexmk)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,7 +2,7 @@
 # It's tailored for running tests and building documentation.
 
 FROM ubuntu:jammy AS build
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \


### PR DESCRIPTION
Only newer Cython versions generate code that is compatible with Python 3.12. The [currently used Cython version](https://packages.debian.org/bookworm/cython3) is too old. This PR will add a check to the `build_cython` setup step to ensure that we use at least version 3.0.0 of Cython to generate the C++ code.

fixes #368 

You might need to alter `make_release.sh` to use a virtual environment or install a newer version of Cython globally.