### PR TITLE
Fix mount.s3ql --metadata-backup-interval=0

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+Unreleased Changes
+==================
+
+* Running *mount.s3ql* with `--metadata-backup-interval=-` no longer crashes.
+
+
 S3QL 5.4.0 (2025-09-06)
 =======================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,7 +1,7 @@
 Unreleased Changes
 ==================
 
-* Running *mount.s3ql* with `--metadata-backup-interval=-` no longer crashes.
+* Running *mount.s3ql* with `--metadata-backup-interval=0` no longer crashes.
 
 
 S3QL 5.4.0 (2025-09-06)

--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -684,7 +684,10 @@ class MetadataUploadTask:
         log.debug('started')
 
         while not self.quit:
-            with trio.move_on_after(self.options.metadata_backup_interval):
+            if self.options.metadata_backup_interval:
+                with trio.move_on_after(self.options.metadata_backup_interval):
+                    await self.event.wait()
+            else:
                 await self.event.wait()
 
             if self.quit:


### PR DESCRIPTION
Previously, this would result in a crash because trio.move_on_after does not take `None` as an argument.