### PR TITLE
Use dependency groups instead of optional dependencies for dev deps

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -21,38 +21,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
         deps: [ dist, latest ]
-    steps:
-      - uses: actions/checkout@v4
-      - run: 'sudo apt-get update'
-      - run: python3 -m venv venv
-      - run: tests/ci-prepare-${{ matrix.deps }}.sh
-      - run: venv/bin/pip install --upgrade pip
-      - run: venv/bin/pip install .[dev]
-      - run: '. venv/bin/activate && pytest -r s tests/'
-      - run: '. venv/bin/activate && ./build_docs.sh'
-  check-style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-
-      - name: Run Ruff Formatter
-        run: ruff format --diff
-
-      - name: Run Ruff Linter
-        run: ruff check --output-format=github .
-  supported-python-versions:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
         python-version:
           - "3.13"
           - "3.12"
@@ -61,15 +29,43 @@ jobs:
           - "3.9"
           - "3.8"
     steps:
-      - uses: actions/checkout@v4
-      - run: 'sudo apt-get update'
-      - run: tests/ci-prepare-dist.sh
+      - name: Checkout source
+        uses: actions/checkout@v4
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - name: Install the project
-        run: uv sync --locked --all-extras
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          tests/ci-prepare-${{ matrix.deps }}.sh
+
+      - name: Build S3QL
+        run: uv sync --locked
+
       - name: Run tests
         run: uv run pytest -r s tests/
+
+      - name: Build documentation
+        run: uv run ./build_docs.sh
+
+  check-style:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run formatter
+        run: uv tool run ruff format --diff
+
+      - name: Run linter
+        run: uv tool run ruff check --output-format=github .

--- a/developer-notes/setup.md
+++ b/developer-notes/setup.md
@@ -11,8 +11,8 @@ by hand as follows:
 $ python3 -m venv .venv   # create the venv
 $ . .venv/bin/activate    # activate it
 $ pip install --upgrade pip # upgrade pip
-$ pip install .[dev]      # build & install S3QL and dependencies
-$ pip install --no-build-isolation --editable .  # re-install in editable mode
+$ pip install --group dev # install build dependencies
+$ pip install --no-build-isolation --editable .  # install s3ql in editable mode
 ```
 
 As long as the venv is active, you can run tests with

--- a/make_release.sh
+++ b/make_release.sh
@@ -14,7 +14,7 @@ echo "Creating release tarball for ${TAG}..."
 
 git checkout -q "${TAG}"
 
-uv sync --frozen --extra dev
+uv sync --frozen
 . .venv/bin/activate
 
 # check if we have a recent enough Cython version so that the release tarball is compatible with Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "pyfuse3 >= 3.2.0, < 4.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-trio",

--- a/uv.lock
+++ b/uv.lock
@@ -1046,7 +1046,7 @@ wheels = [
 
 [[package]]
 name = "s3ql"
-version = "5.3.0"
+version = "5.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "apsw", version = "3.46.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -1061,7 +1061,7 @@ dependencies = [
     { name = "trio", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "cython" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -1080,20 +1080,23 @@ dev = [
 requires-dist = [
     { name = "apsw", specifier = ">=3.42.0" },
     { name = "cryptography" },
-    { name = "cython", marker = "extra == 'dev'" },
     { name = "defusedxml" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "pyfuse3", specifier = ">=3.2.0,<4.0" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-trio", marker = "extra == 'dev'" },
     { name = "requests" },
-    { name = "ruff", marker = "extra == 'dev'" },
-    { name = "setuptools", marker = "extra == 'dev'" },
-    { name = "sphinx", marker = "extra == 'dev'" },
     { name = "trio", specifier = ">=0.15" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "cython" },
+    { name = "pytest" },
+    { name = "pytest-trio" },
+    { name = "ruff" },
+    { name = "setuptools" },
+    { name = "sphinx" },
+]
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
Optional dependencies are intended to enable optional program features, not to declare what's needed for development.

See eg. https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups and https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies