### PR TITLE
Do not write updated params until after metadata blocks has been expired

### DIFF
--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -352,9 +352,9 @@ async def main_async(options, stdout_log_handler):
     with backend_pool() as backend:
         param.last_modified = time.time()
         upload_metadata(backend, db, param)
+        expire_objects(backend)
         write_params(cachepath, param)
         upload_params(backend, param)
-        expire_objects(backend)
 
     log.info('All done.')
 


### PR DESCRIPTION


I feel like there is a potential race condition here when mounting and unmounting the filesystem while a metadata expiration operation is still ongoing. Doing things this way around seems safer.