### PR TITLE
Add new `s3qladm vacuum` command.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+Unreleased Changes
+==================
+
+* There is a new `s3qladm shrink-db` command that reclaims unused space in the
+  metadata database (both on disk and in the backend storage).
+
 S3QL 5.4.1 (2025-11-01)
 =======================
 

--- a/rst/adm.rst
+++ b/rst/adm.rst
@@ -83,6 +83,15 @@ A file system can be deleted with::
 This physically deletes all the data and file system structures.
 
 
+Recovering unused space
+-----------------------
+
+When deleting files and directories, the corresponding space in the metadata
+database is not immediately reclaimed but marked as free and reused when new
+directory entries are created. To reclaim this space, and reduce the size of
+the metadata file on disk and in the backend, you can run::
+
+  s3qladm shrink-db <storage url>
 
 
 Upgrading the file system

--- a/tests/t4_fuse.py
+++ b/tests/t4_fuse.py
@@ -29,7 +29,7 @@ from common import RetryTimeoutError, retry, skip_if_no_fusermount
 from pytest import raises as assert_raises
 
 from s3ql import CTRL_NAME
-from s3ql.common import path2bytes
+from s3ql.common import escape, path2bytes
 
 # For debugging
 USE_VALGRIND = False
@@ -57,6 +57,7 @@ class TestFuse:
 
         self.mount_process = None
         self.name_cnt = 0
+        self.cachepath = os.path.join(self.cache_dir, escape(self.storage_url))
 
     def mkfs(self, max_obj_size=500):
         argv = [


### PR DESCRIPTION
This can be used to recover unused space in the metadata file.