### PR TITLE
fix(tests): add support for backend options in test suite

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -306,6 +306,9 @@ def get_remote_test_info(name):
         fs_name = config.get(name, 'test-fs')
         backend_login = config.get(name, 'backend-login')
         backend_password = config.get(name, 'backend-password')
+        backend_options = config.get(name, 'backend-options', fallback=None)
+        if isinstance(backend_options, str) and not backend_options.strip():
+            backend_options = None
     except (configparser.NoOptionError, configparser.NoSectionError):
         raise NoTestSection("Authentication file does not have %s section" % name)
 
@@ -314,4 +317,4 @@ def get_remote_test_info(name):
         fs_name += '/'
     fs_name += 's3ql_test_%d/' % time.time()
 
-    return (backend_login, backend_password, fs_name)
+    return (backend_login, backend_password, backend_options, fs_name)

--- a/tests/t1_backends.py
+++ b/tests/t1_backends.py
@@ -41,6 +41,7 @@ from s3ql.backends.comprenc import (
 )
 from s3ql.backends.s3c import BadDigestError, HTTPError, OperationAbortedError, S3Error
 from s3ql.http import ConnectionClosed
+from s3ql.parse_args import suboptions_type
 from s3ql.types import BasicMappingT
 
 log = logging.getLogger(__name__)
@@ -83,7 +84,11 @@ def _get_backend_info():
             continue
 
         try:
-            (login, password, storage_url) = get_remote_test_info(name + '-test')
+            (login, password, options, storage_url) = get_remote_test_info(name + '-test')
+            if options is None:
+                options = {}
+            else:
+                options = suboptions_type(options)
         except NoTestSection as exc:
             log.info('Not running remote tests for %s backend: %s', name, exc.reason)
             continue
@@ -94,6 +99,7 @@ def _get_backend_info():
         bi.storage_url = storage_url
         bi.login = login
         bi.password = password
+        bi.options = options
         info.append(bi)
 
     # Backends talking to local mock servers
@@ -258,7 +264,7 @@ async def yield_remote_backend(bi, _ctr=[0]):  # noqa: B006
             storage_url=storage_url,
             backend_login=bi.login,
             backend_password=bi.password,
-            backend_options={},
+            backend_options=bi.options,
         )
     )
 

--- a/tests/t4_fuse.py
+++ b/tests/t4_fuse.py
@@ -54,6 +54,7 @@ class TestFuse:
         self.passphrase = 'oeut3d'
         self.backend_login = None
         self.backend_passphrase = None
+        self.backend_options = None
 
         self.mount_process = None
         self.name_cnt = 0
@@ -73,6 +74,8 @@ class TestFuse:
             '/dev/null',
             self.storage_url,
         ]
+        if self.backend_options is not None:
+            argv += ['--backend-options', self.backend_options]
         if self.passphrase is None:
             argv.append('--plain')
 
@@ -106,9 +109,12 @@ class TestFuse:
             '--authfile',
             '/dev/null',
         ]
+        if self.backend_options is not None:
+            cmd += ['--backend-options', self.backend_options]
         if in_foreground:
             cmd += ["--fg"]
         cmd += extra_args
+
         self.mount_process = subprocess.Popen(cmd, stdin=subprocess.PIPE, universal_newlines=True)
         if self.backend_login is not None:
             print(self.backend_login, file=self.mount_process.stdin)
@@ -148,7 +154,11 @@ class TestFuse:
 
     def fsck(self, expect_retcode=0, args=None):
         if args is None:
-            args = []
+            extra_args = []
+        else:
+            extra_args = args[:]
+        if self.backend_options is not None:
+            extra_args += ['--backend-options', self.backend_options]
         proc = subprocess.Popen(
             [
                 'fsck.s3ql',
@@ -162,7 +172,7 @@ class TestFuse:
                 '/dev/null',
                 self.storage_url,
             ]
-            + args,
+            + extra_args,
             stdin=subprocess.PIPE,
             universal_newlines=True,
         )

--- a/tests/t5_failsafe.py
+++ b/tests/t5_failsafe.py
@@ -40,8 +40,9 @@ class TestFailsafe(t4_fuse.TestFuse):
     def setup_method(self, method):
         super().setup_method(method)
         try:
-            (backend_login, backend_pw, self.storage_url) = get_remote_test_info('gs-test')
+            (backend_login, backend_pw, _, self.storage_url) = get_remote_test_info('gs-test')
         except NoTestSection as exc:
+            # super().setup_method() created directories that we need to clean up
             super().teardown_method(method)
             pytest.skip(exc.reason)
 

--- a/tests/t6_upgrade.py
+++ b/tests/t6_upgrade.py
@@ -262,12 +262,16 @@ class RemoteUpgradeTest:
     def setup_method(self, method, name):
         super().setup_method(method)
         try:
-            (backend_login, backend_pw, self.storage_url) = get_remote_test_info(name)
+            (backend_login, backend_pw, backend_options, self.storage_url) = get_remote_test_info(
+                name
+            )
         except NoTestSection as exc:
+            # super().setup_method() created directories that we need to clean up
             super().teardown_method(method)
             pytest.skip(exc.reason)
         self.backend_login = backend_login
         self.backend_passphrase = backend_pw
+        self.backend_options = backend_options
 
     def populate(self):
         populate_dir(self.ref_dir, entries=50, size=5 * 1024 * 1024)
@@ -275,11 +279,11 @@ class RemoteUpgradeTest:
     def teardown_method(self, method):
         super().teardown_method(method)
 
-        proc = subprocess.Popen(
-            ['s3qladm', '--quiet', '--authfile', '/dev/null', 'clear', self.storage_url],
-            stdin=subprocess.PIPE,
-            universal_newlines=True,
-        )
+        args = ['s3qladm', '--quiet', '--authfile', '/dev/null']
+        if self.backend_options is not None:
+            args += ['--backend-options', self.backend_options]
+        args += ['clear', self.storage_url]
+        proc = subprocess.Popen(args, stdin=subprocess.PIPE, universal_newlines=True)
         if self.backend_login is not None:
             print(self.backend_login, file=proc.stdin)
             print(self.backend_passphrase, file=proc.stdin)


### PR DESCRIPTION
Extended multiple tests to handle optional backend options. Adjusted relevant subprocess calls and configuration parsing to include support for `--backend-options`.

This is necessary to run OpenStack Swift Keystone v3 remote tests.