### PR TITLE
BackendPool(): Limit maximum number of connections.

### DIFF
--- a/src/s3ql/mount.py
+++ b/src/s3ql/mount.py
@@ -215,7 +215,7 @@ async def main_async(options: Namespace, stdout_log_handler: ConsoleHandler | No
     # Get paths
     cachepath = options.cachepath
 
-    backend_pool = BackendPool(await get_backend_factory(options))
+    backend_pool = BackendPool(await get_backend_factory(options), options.max_connections)
     async with backend_pool() as backend:
         (param, db) = await get_metadata(backend, cachepath)
 
@@ -250,7 +250,6 @@ async def main_async(options: Namespace, stdout_log_handler: ConsoleHandler | No
             cachepath + '-cache',
             options.cachesize * 1024,
             max_entries=options.max_cache_entries,
-            connections=options.max_connections,
             nursery=nursery,
         )
         cm.push_async_callback(block_cache.destroy, options.keep_cache)

--- a/tests/t2_block_cache.py
+++ b/tests/t2_block_cache.py
@@ -89,7 +89,7 @@ async def ctx():
         return await AsyncComprencBackend.create(b'foobar', ('zlib', 6), plain)
 
     factory.has_delete_multi = True
-    ctx.backend_pool = BackendPool(factory)
+    ctx.backend_pool = BackendPool(factory, max_connections=10)
 
     ctx.cachedir = tempfile.mkdtemp(prefix='s3ql-cache-')
     ctx.max_obj_size = 1024

--- a/tests/t3_fs_api.py
+++ b/tests/t3_fs_api.py
@@ -81,7 +81,7 @@ async def ctx(tmp_path):
         return await AsyncComprencBackend.create(b'schwubl', ('zlib', 6), plain)
 
     factory.has_delete_multi = True
-    ctx.backend_pool = BackendPool(factory)
+    ctx.backend_pool = BackendPool(factory, max_connections=10)
 
     ctx.backend = await ctx.backend_pool.pop_conn()
     ctx.cachedir = tmp_path / 'cache'


### PR DESCRIPTION
This enables us to distribute connections between object upload, download and removal as needed.

Also remove the pointless trio.Lock that no longer fulfills a function.