### PR TITLE
backblaze b2 backend: fix auth procedure

### DIFF
--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -51,7 +51,7 @@ from .b2_error import B2Error, BadDigestError
 
 log = logging.getLogger(__name__)
 
-api_url_prefix = '/b2api/v2/'
+api_url_prefix = '/b2api/v4/'
 info_header_prefix = 'X-Bz-Info-'
 
 
@@ -228,17 +228,28 @@ class AsyncB2Backend(AsyncBackend):
 
             self.account_id = j['accountId']
 
-            allowed_info = j.get('allowed')
-            if allowed_info.get('bucketId'):
-                self.bucket_id = allowed_info.get('bucketId')
-                if allowed_info.get('bucketName') != self.bucket_name:
-                    raise RuntimeError('Provided API key can not access desired bucket.')
+            apiInfo = j['apiInfo']
+            storageApi = apiInfo['storageApi']
+
+            allowed_info = storageApi['allowed']
+            allowed_buckets = allowed_info['buckets']
+            if allowed_buckets:
+                errmsg = 'Provided API key can not access desired bucket, it can access {} buckets: '.format(len(allowed_buckets))
+                for bucket in allowed_buckets:
+                    errmsg += bucket['name'] + ','
+                    if bucket['name'] == self.bucket_name:
+                        self.bucket_id = bucket['id']
+                        break
+                if self.bucket_id == None:
+                    raise RuntimeError(errmsg)
+            elif self.bucket_id == None:
+                raise RuntimeError('Provided API key can not access any specific buckets.')
 
             if not self._check_key_capabilities(allowed_info):
                 raise RuntimeError('Provided API key does not have the required capabilities.')
 
-            self.api_url = urlparse(j['apiUrl'])
-            self.download_url = urlparse(j['downloadUrl'])
+            self.api_url = urlparse(storageApi['apiUrl'])
+            self.download_url = urlparse(storageApi['downloadUrl'])
             self.authorization_token = j['authorizationToken']
 
     def _check_key_capabilities(self, allowed_info):


### PR DESCRIPTION
Auth is working, but it now fails with:
```
2026-04-10 12:21:45.087 19234 ERROR    MainThread __main__.excepthook: Uncaught top-level exception:
  + Exception Group Traceback (most recent call last):
  |   File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/adm.py", line 269, in clear
  |     async with trio.open_nursery() as nursery:
  |   File "/build/mx/s3ql/s3ql-2026-04-04/devenv/lib/python3.12/site-packages/trio/_core/_run.py", line 1126, in __aexit__
  |     raise combined_error_from_nursery
  | ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/adm.py", line 265, in removal_task
    |     async with recv, await options.backend_class.create(options) as worker_backend:
    |   File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/backends/common.py", line 257, in __aexit__
    |     await self.close()
    | TypeError: object NoneType can't be used in 'await' expression
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/build/mx/s3ql/s3ql-2026-04-04/devenv/bin/s3qladm", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/adm.py", line 139, in main
    trio.run(main_async, options)
  File "/build/mx/s3ql/s3ql-2026-04-04/devenv/lib/python3.12/site-packages/trio/_core/_run.py", line 2552, in run
    raise runner.main_task_outcome.error
  File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/adm.py", line 144, in main_async
    await clear(options)
  File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/adm.py", line 231, in clear
    async with await async_get_backend(options, raw=True) as backend:
  File "/build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/backends/common.py", line 257, in __aexit__
    await self.close()
TypeError: object NoneType can't be used in 'await' expression
```