### PR TITLE
Backblaze b2: Fix the async close() function

### DIFF
--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -673,8 +673,8 @@ class AsyncB2Backend(AsyncBackend):
         file_name = self._b2_escape_backslashes(file_name)
         return file_id, file_name
 
-    def close(self):
-        self._reset_connections()
+    async def close(self):
+        self._close_connections()
 
     @retry
     async def _get_upload_conn(self):


### PR DESCRIPTION
Carrying on from #424 , except we leave B2's API at v2.
this only changes the def close(), which needed to be async,
and, should call _close_connections() rather than _recent_connections(). I think.

There is still a problem when running 
`pytest tests/t5_full.py`

```
WARNING: /build/mx/s3ql/s3ql-2026-04-04/s3ql/src/s3ql/backends/common.py:-1: ResourceWarning: unclosed <ssl.SSLSocket fd=14, family=2, type=1, proto=6, laddr=('x.x.x.x', 35408)>
```