### PR TITLE
Rewrite Backblaze B2 backend on top of the S3-compatible API

### DIFF
--- a/rst/backends.rst
+++ b/rst/backends.rst
@@ -409,65 +409,61 @@ Backblaze B2
 
 .. program:: b2_backend
 
-Backblaze B2 is a cloud storage with its own API.
-
-.. warning::
-
-   S3QL developers do not have access to a Backblaze instance, so this backend is not
-   being tested before release and may break randomly. This backend depends on Backblaze
-   users to test and maintain it (aka submit pull requests when it doesn't work).
-
-The storage URL for backblaze b2 storage is ::
+The Backblaze B2 backend uses Backblaze's S3-compatible API with AWS
+Signature V4 authentication. The storage URL is ::
 
    b2://<bucket-name>[/<prefix>]
 
-*bucket-name* is an (existing) bucket which has to be accessible with
-the provided account key. The *prefix* will be appended to all names
-used by S3QL and can be used to hold separate S3QL repositories in the
-same bucket.
+*bucket-name* is an existing bucket accessible with the provided
+application key. The bucket's region is discovered automatically at
+startup. *prefix* is prepended to all object names used by S3QL and can
+be used to hold several S3QL file systems in the same bucket.
 
-It is also possible to use an application key. The required key capabilities
-are the following:
+The backend login is a Backblaze application key ID and the password is
+the corresponding application key. The required key capabilities are
+``listBuckets``, ``listFiles``, ``readFiles``, ``writeFiles``, and
+``deleteFiles``.
 
-   - `listBuckets`
-   - `listFiles`
-   - `readFiles`
-   - `writeFiles`
-   - `deleteFiles`
+The Backblaze B2 backend accepts the following backend options:
 
-.. option:: disable-versions
+.. option:: no-ssl
 
-   If versioning of the bucket is not enabled, this option can be set.
-   When deleting objects, the bucket will not be scanned for all file versions
-   because it will be implied that only the one (the most recent) version of a
-   file exists. This will use only one class B transaction instead of
-   (possibly) multiple class C transactions.
+   Disable encrypted (https) connections and use plain HTTP instead.
 
-.. option:: retry-on-cap-exceeded
+.. option:: ssl-ca-path=<path>
 
-   If there are data/transaction caps set for the backblaze account, this option
-   controls if operations should be retried as cap counters are reset every day.
-   Otherwise the exception would abort the program.
-
-.. option:: test_mode=<value>
-
-   This option puts the backblaze B2 server into test mode by adding a special header to the
-   requests. Use this option only to test the failure resiliency of the backend implementation as it
-   causes unnecessary traffic, delays and transactions.
-
-   Valid values are documented in
-   https://www.backblaze.com/docs/en/cloud-storage-integration-checklist and include:
-
-   - `fail_some_uploads` to randomly fail some uploads.
-   - `expire_some_account_authorization_tokens` to let the server fail some authorization tokens.
-   - `force_cap_exceeded` to let the server to behave as if the data/transaction caps were exceeded.
-
+   Instead of using the system's default certificate store, validate
+   the server certificate against the specified CA
+   certificates. :var:`<path>` may be either a file containing
+   multiple certificates, or a directory containing one certificate
+   per file.
 
 .. option:: tcp-timeout
 
    Specifies the timeout used for TCP connections. If no data can be
    exchanged with the remote server for longer than this period, the
    TCP connection is closed and re-established (default: 20 seconds).
+
+
+Fallback: b2old
+---------------
+
+The ``b2old://`` URL scheme selects the legacy backend that talks to
+Backblaze's native B2 API. It exists as a temporary escape hatch in
+case a regression is found in the S3-compatible backend and will be
+removed in a future release. The storage URL is ::
+
+   b2old://<bucket-name>[/<prefix>]
+
+The ``b2old`` backend accepts the same options as in earlier S3QL releases
+(``disable-versions``, ``retry-on-cap-exceeded``, ``test_mode``,
+``tcp-timeout``). Their semantics are unchanged from the previous native-API
+implementation.
+
+A filesystem originally created with ``b2old://`` can be read via ``b2://``;
+the new backend recognises the metadata layout used by the legacy code. New
+writes use the standard S3 metadata layout, so a filesystem migrates
+incrementally as objects are rewritten.
 
 .. _Backblaze B2 API: https://www.backblaze.com/b2/docs/
 

--- a/src/s3ql/backends/__init__.py
+++ b/src/s3ql/backends/__init__.py
@@ -8,7 +8,7 @@ This work can be distributed under the terms of the GNU GPLv3.
 
 from s3ql.backends.common import AsyncBackend
 
-from . import gs, local, rackspace, s3, s3c, s3c4, swift, swiftks
+from . import b2ng, gs, local, rackspace, s3, s3c, s3c4, swift, swiftks
 from .b2 import b2_backend as b2
 
 async_prefix_map: dict[str, type[AsyncBackend]] = {
@@ -20,5 +20,6 @@ async_prefix_map: dict[str, type[AsyncBackend]] = {
     'swift': swift.AsyncBackend,
     'swiftks': swiftks.AsyncBackend,
     'rackspace': rackspace.AsyncBackend,
-    'b2': b2.AsyncB2Backend,
+    'b2': b2ng.AsyncBackend,
+    'b2old': b2.AsyncB2Backend,
 }

--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -121,7 +121,7 @@ class AsyncB2Backend(AsyncBackend):
         Return a tuple * (bucket_name, prefix) * .
         '''
 
-        hit = re.match(r'^b2://([^/]+)(?:/(.*))?$', storage_url)
+        hit = re.match(r'^b2(?:old)?://([^/]+)(?:/(.*))?$', storage_url)
 
         if not hit:
             raise QuietError('Invalid storage URL', exitcode=2)

--- a/src/s3ql/backends/b2ng.py
+++ b/src/s3ql/backends/b2ng.py
@@ -1,0 +1,118 @@
+'''
+b2ng.py - this file is part of S3QL.
+
+Copyright © 2008 Nikolaus Rath <Nikolaus@rath.org>
+
+This work can be distributed under the terms of the GNU GPLv3.
+'''
+
+from __future__ import annotations
+
+import logging
+import re
+import ssl
+
+from s3ql.http import CaseInsensitiveDict, HTTPResponse
+from s3ql.types import BackendOptionsProtocol, BasicMappingT
+
+from ..logging import QuietError
+from . import s3c4
+
+log = logging.getLogger(__name__)
+
+# Backblaze accepts requests for any of its S3 endpoints and replies with a
+# 301 carrying `x-amz-bucket-region` pointing at the correct one. We start
+# requests against this region and re-target on the first response.
+DEFAULT_REGION = 'us-east-005'
+
+
+class AsyncBackend(s3c4.AsyncBackend):
+    """Backblaze B2 via its S3-compatible API (SigV4)."""
+
+    known_options: set[str] = s3c4.AsyncBackend.known_options - {'sig-region'}
+
+    def __init__(self, *, options: BackendOptionsProtocol) -> None:
+        '''Initialize backend object - use AsyncBackend.create() instead.'''
+        super().__init__(options=options)
+        # `s3c4` reads `sig-region` from backend options (defaulting to
+        # `us-east-1`). We override unconditionally; the real region is
+        # discovered in `_discover_region`.
+        self.sig_region = DEFAULT_REGION
+
+    @classmethod
+    async def create(cls: type[AsyncBackend], options: BackendOptionsProtocol) -> AsyncBackend:
+        '''Create a new Backblaze B2 (S3-compatible) backend instance.'''
+        self = cls(options=options)
+        await self._discover_region()
+        return self
+
+    def _parse_storage_url(
+        self, storage_url: str, ssl_context: ssl.SSLContext | None
+    ) -> tuple[str, int, str, str]:
+        hit = re.match(r'^b2://([^/]+)(?:/(.*))?$', storage_url)
+        if not hit:
+            raise QuietError('Invalid storage URL', exitcode=2)
+
+        bucket_name = hit.group(1)
+
+        # https://www.backblaze.com/docs/cloud-storage-create-and-manage-buckets#bucket-names
+        if not re.match(r'^[a-z0-9][a-z0-9-]{4,61}[a-z0-9]$', bucket_name):
+            raise QuietError('Invalid bucket name.', exitcode=2)
+
+        prefix = hit.group(2) or ''
+        hostname = 's3.%s.backblazeb2.com' % DEFAULT_REGION
+        port = 443 if ssl_context else 80
+        return (hostname, port, bucket_name, prefix)
+
+    async def _discover_region(self) -> None:
+        '''Resolve the bucket's region and re-target subsequent requests.'''
+
+        # Backblaze replies to a request to any S3 endpoint with the bucket's actual region in the
+        # `x-amz-bucket-region` header, accompanied by a 301 if the endpoint was wrong. We issue a
+        # single HEAD bypassing the redirect-following logic in `_do_request` so we can read the
+        # header ourselves.
+
+        resp = await self._do_request_inner('HEAD', '/', headers=CaseInsensitiveDict())
+        region = resp.headers.get('x-amz-bucket-region')
+
+        if region is None and not (200 <= resp.status <= 299):
+            # Non-2xx with no region hint: nothing to recover. Surface as a
+            # typed error (auth failure, no-such-bucket, ...).
+            await self._parse_error_response(resp)
+            return  # unreachable; _parse_error_response always raises.
+
+        await self.conn.discard()
+
+        if region is not None and region != self.sig_region:
+            log.debug('Bucket region is %s, re-targeting connection', region)
+            self.sig_region = region
+            self.hostname = 's3.%s.backblazeb2.com' % region
+            self.signing_key = None
+            await self.conn.aclose()
+            self.conn = self._get_conn()
+
+    def _extractmeta(self, resp: HTTPResponse, obj_key: str) -> BasicMappingT:
+        '''Extract metadata'''
+
+        # The native (non-S3) B2 backend stored S3QL metadata in `X-Bz-Info-meta-*` file-info
+        # entries. Backblaze's S3-compatible endpoint surfaces those as `x-amz-meta-meta-*` headers,
+        # so a filesystem originally created via `b2old://` would otherwise look like an unknown
+        # metadata format here. When the standard `x-amz-meta-format` header is absent but
+        # `x-amz-meta-meta-format` is present, re-run the standard extraction with the header prefix
+        # shifted by one `meta-` segment.
+
+        if '%smeta-format' % self.hdr_prefix in resp.headers:
+            return super()._extractmeta(resp, obj_key)
+        if '%smeta-meta-format' % self.hdr_prefix not in resp.headers:
+            # Neither layout present — defer to the parent so it raises the
+            # standard `Invalid metadata format` error.
+            return super()._extractmeta(resp, obj_key)
+        saved_prefix = self.hdr_prefix
+        self.hdr_prefix = saved_prefix + 'meta-'
+        try:
+            return super()._extractmeta(resp, obj_key)
+        finally:
+            self.hdr_prefix = saved_prefix
+
+    def __str__(self) -> str:
+        return 'Backblaze B2 bucket %s, prefix %s' % (self.bucket_name, self.prefix)


### PR DESCRIPTION
The native B2 backend has been a long-standing maintenance burden. The S3QL
developers do not have a Backblaze account, the B2 native API is unique to
this provider, and the code path is exercised by no automated test before a
release. As a result the backend has historically drifted out of shape
between releases and depended on user pull requests to recover.

Backblaze now exposes an S3-compatible endpoint that speaks the same protocol
as `s3c4`. Routing `b2://` through that endpoint replaces the bulk of the B2
code with a thin subclass of `s3c4.AsyncBackend`. The new backend lives in
`backends/b2ng.py`. It parses the existing `b2://<bucket>[/<prefix>]` URL,
discovers the bucket's region with a single HEAD against a default endpoint
(reading `x-amz-bucket-region`), and lets the SigV4 machinery in `s3c4`
handle authentication, listing, transfer, and retry. The S3-compatible path
is automatically covered by the standard backend test suite via the
`b2-test` authinfo2 section, so the backend now follows the same release
gate as the other S3-style backends.

To keep filesystems originally created with the native backend readable,
`_extractmeta` is overridden to recognise the legacy header layout. The
native backend stored S3QL metadata in `X-Bz-Info-meta-*` file-info entries;
Backblaze's S3-compatible endpoint surfaces those as `x-amz-meta-meta-*`
headers. When the standard `x-amz-meta-format` marker is absent but its
doubled-prefix counterpart is present, extraction re-runs against the
shifted prefix. New writes use the standard s3c layout, so a filesystem
migrates to the new format incrementally as fsck or normal operation
rewrites objects.

The legacy native-API backend remains available under a new `b2old://` URL
scheme as a temporary fallback for users hitting a regression. It is
scheduled for removal in a future release.
