### PR TITLE
ci: build docs directly instead of via removed `build_docs.sh`

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -60,7 +60,9 @@ jobs:
         run: uv run pytest -r s tests/
 
       - name: Build documentation
-        run: uv run ./build_docs.sh
+        run: |
+          uv run sphinx-build -W --keep-going -d doc/doctrees -b html rst/ doc/html/
+          uv run sphinx-build -W --keep-going -d doc/doctrees -b man rst/ doc/manpages/
 
   check-style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Build documentation` step in `pr-ci.yml` invokes `uv run ./build_docs.sh`, but that helper script no longer exists in the repository. CI fails on that step on every run.

The workflow now calls `sphinx-build` directly, building both the HTML and man-page targets with `-W --keep-going` and a shared doctree directory. This matches the invocation used by the release tooling in `util/make_release.py`, so CI exercises the same builders that a release would run and catches doc warnings before they reach a tag.